### PR TITLE
Added travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+python:
+    - 3.4
+    - 3.5
+    - 3.6
+cache: pip
+install: 
+    - pip install .[test]
+
+script:
+    - flake8 .
+
+branches:
+  only:
+    - master
+    - develop

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 100
-select = E,W,F,I,C,Q,T,B
+select = E,W,F,I,C,Q,T
 application-import-names = ark

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ requires = [
 
 tests_require = [
     'flake8>=3.5.0',
-    'flake8-bugbear>=18.2.0',
     'flake8-import-order>=0.17.1',
     'flake8-quotes>=1.0.0',
 ]


### PR DESCRIPTION
Travis CI setup.

As we aim to support python version 3.4, I removed flake8-bugbear as it requires python 3.5+ to work.
