### PR TITLE
Changed the print() in API to log instead.

### DIFF
--- a/ark/one/api.py
+++ b/ark/one/api.py
@@ -1,6 +1,10 @@
 from abc import ABC
+import logging
 
 import requests
+
+
+logger = logging.getLogger(__name__)
 
 
 class API(ABC):
@@ -35,7 +39,8 @@ class API(ABC):
         body = response.json()
 
         if body['success'] is False:
-            print(body['error'])
+            log_msg = '{} {} - {}'.format(method.upper(), path, body['error'])
+            logger.error(log_msg)
 
         return body
 

--- a/ark/one/api.py
+++ b/ark/one/api.py
@@ -1,5 +1,5 @@
-from abc import ABC
 import logging
+from abc import ABC
 
 import requests
 


### PR DESCRIPTION
I updated the print function in the API sendRequest() to log as an error instead. I don't think it's a good idea for an API to print anything to stdout. That should be left to the application using the API.