### PR TITLE
Added initial tests after refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __pycache__/
 *.python-version
 *.eggs
 *.pytest_cache/
+.coverage
+htmlcov/
+.cache/

--- a/ark/client.py
+++ b/ark/client.py
@@ -31,7 +31,7 @@ class ArkClient(object):
         """
         version = VERSION_TO_STRING_MAPPING[self.api_version]
         # Get all modules under the wanted version folder
-        modules = pkgutil.iter_modules([str(Path(__file__).parent / 'api' / version)])
+        modules = pkgutil.iter_modules([Path(__file__).parent / 'api' / version])
         for _, name, _ in modules:
             module = import_module('.{}'.format(name), package='ark.api.{}'.format(version))
 

--- a/ark/client.py
+++ b/ark/client.py
@@ -31,7 +31,7 @@ class ArkClient(object):
         """
         version = VERSION_TO_STRING_MAPPING[self.api_version]
         # Get all modules under the wanted version folder
-        modules = pkgutil.iter_modules([Path(__file__).parent / 'api' / version])
+        modules = pkgutil.iter_modules([str(Path(__file__).parent / 'api' / version)])
         for _, name, _ in modules:
             module = import_module('.{}'.format(name), package='ark.api.{}'.format(version))
 

--- a/tests/api/one/env.py
+++ b/tests/api/one/env.py
@@ -1,0 +1,2 @@
+VERSION = '1.1.1'
+API_VERSION = 'v1'

--- a/tests/api/one/test_account.py
+++ b/tests/api/one/test_account.py
@@ -1,0 +1,84 @@
+import pytest
+
+import tests.api.one.env as env_v1
+import tests.env as env
+
+
+from ark.client import ArkClient
+
+
+ARK = ArkClient(
+    env.HOST,
+    env.PORT,
+    env.NETHASH,
+    env_v1.VERSION,
+    api_version=env_v1.API_VERSION
+)
+
+
+def test_balance():
+    res = ARK.account.balance(env.ADDRESS)
+    assert res['success'] is True
+    assert 'balance' in res
+    assert 'unconfirmedBalance' in res
+
+
+def test_public_key():
+    res = ARK.account.public_key(env.ADDRESS)
+    assert res['success'] is True
+    assert res['publicKey'] == env.PUBLIC_KEY
+
+
+def test_delegates():
+    res = ARK.account.delegates(env.ADDRESS)
+    assert res['success'] is True
+    assert 'delegates' in res
+
+
+def test_delegates_fee():
+    res = ARK.account.delegates_fee()
+    assert res['success'] is True
+    assert 'fee' in res
+
+
+def test_account():
+    res = ARK.account.account(env.ADDRESS)
+    assert res['success'] is True
+    assert 'account' in res
+
+
+@pytest.mark.skip('Server is returning "API endpoint was not found"')
+def test_account():
+    res = ARK.account.account()
+    assert res['success'] is True
+    assert len(res['accounts']) == 100
+
+
+@pytest.mark.skip('Server is returning "API endpoint was not found"')
+def test_accounts_with_parameters():
+    parameters = {'limit': 1}
+    res = ARK.account.accounts(parameters=parameters)
+    assert res['success'] is True
+    assert len(res['accounts']) == 1
+
+
+@pytest.mark.skip('Server is returning "API endpoint was not found"')
+def test_top():
+    res = ARK.account.top()
+    assert res['success'] is True
+    assert len(res['accounts']) == 100
+
+
+@pytest.mark.skip('Server is returning "API endpoint was not found"')
+def test_top_with_parameters():
+    parameters = {'limit': 1}
+    res = ARK.account.top(parameters=parameters)
+    assert res['success'] is True
+    assert len(res['accounts']) == 1
+
+
+@pytest.mark.skip('Server is returning "API error: Cannot convert undefined or null to object"')
+def test_count():
+    res = ARK.account.count()
+    assert res['success'] is True
+    assert 'account' in res

--- a/tests/api/one/test_account.py
+++ b/tests/api/one/test_account.py
@@ -48,7 +48,7 @@ def test_account():
 
 
 @pytest.mark.skip('Server is returning "API endpoint was not found"')
-def test_accounts():
+def test_account():
     res = ARK.account.account()
     assert res['success'] is True
     assert len(res['accounts']) == 100

--- a/tests/api/one/test_account.py
+++ b/tests/api/one/test_account.py
@@ -48,7 +48,7 @@ def test_account():
 
 
 @pytest.mark.skip('Server is returning "API endpoint was not found"')
-def test_account():
+def test_accounts():
     res = ARK.account.account()
     assert res['success'] is True
     assert len(res['accounts']) == 100

--- a/tests/api/one/test_account.py~
+++ b/tests/api/one/test_account.py~
@@ -1,0 +1,84 @@
+import pytest
+
+import tests.ark.one.env as env_v1
+import tests.env as env
+
+
+from ark.ark import ArkClient
+
+
+ARK = ArkClient(
+    env.HOST,
+    env.PORT,
+    env.NETHASH,
+    env_v1.VERSION,
+    api_version=env_v1.API_VERSION
+)
+
+
+def test_balance():
+    res = ARK.accounts().balance(env.ADDRESS)
+    assert res['success'] is True
+    assert 'balance' in res
+    assert 'unconfirmedBalance' in res
+
+
+def test_public_key():
+    res = ARK.accounts().public_key(env.ADDRESS)
+    assert res['success'] is True
+    assert res['publicKey'] == env.PUBLIC_KEY
+
+
+def test_delegates():
+    res = ARK.accounts().delegates(env.ADDRESS)
+    assert res['success'] is True
+    assert 'delegates' in res
+
+
+def test_delegates_fee():
+    res = ARK.accounts().delegates_fee()
+    assert res['success'] is True
+    assert 'fee' in res
+
+
+def test_account():
+    res = ARK.accounts().account(env.ADDRESS)
+    assert res['success'] is True
+    assert 'account' in res
+
+
+@pytest.mark.skip('Server is returning "API endpoint was not found"')
+def test_accounts():
+    res = ARK.accounts().accounts()
+    assert res['success'] is True
+    assert len(res['accounts']) == 100
+
+
+@pytest.mark.skip('Server is returning "API endpoint was not found"')
+def test_accounts_with_parameters():
+    parameters = {'limit': 1}
+    res = ARK.accounts().accounts(parameters=parameters)
+    assert res['success'] is True
+    assert len(res['accounts']) == 1
+
+
+@pytest.mark.skip('Server is returning "API endpoint was not found"')
+def test_top():
+    res = ARK.accounts().top()
+    assert res['success'] is True
+    assert len(res['accounts']) == 100
+
+
+@pytest.mark.skip('Server is returning "API endpoint was not found"')
+def test_top_with_parameters():
+    parameters = {'limit': 1}
+    res = ARK.accounts().top(parameters=parameters)
+    assert res['success'] is True
+    assert len(res['accounts']) == 1
+
+
+@pytest.mark.skip('Server is returning "API error: Cannot convert undefined or null to object"')
+def test_count():
+    res = ARK.accounts().count()
+    assert res['success'] is True
+    assert 'account' in res

--- a/tests/api/one/test_block.py
+++ b/tests/api/one/test_block.py
@@ -1,0 +1,94 @@
+import tests.api.one.env as env_v1
+import tests.env as env
+
+from ark.client import ArkClient
+
+
+ARK = ArkClient(
+    env.HOST,
+    env.PORT,
+    env.NETHASH,
+    env_v1.VERSION,
+    api_version=env_v1.API_VERSION
+)
+
+
+def test_block():
+    res = ARK.block.block(env.BLOCK_ID)
+    assert res['success'] is True
+    assert 'block' in res
+
+
+def test_blocks():
+    res = ARK.block.blocks()
+    assert res['success'] is True
+    assert 'blocks' in res
+    assert len(res['blocks']) == 100
+
+
+def test_blocks_with_parameters():
+    parameters = {'limit': 1}
+    res = ARK.block.blocks(parameters=parameters)
+    assert res['success'] is True
+    assert 'blocks' in res
+    assert len(res['blocks']) == 1
+
+
+def test_epoch():
+    res = ARK.block.epoch()
+    assert res['success'] is True
+    assert res['epoch'] == '2017-03-21T13:00:00.000Z'
+
+
+def test_height():
+    res = ARK.block.height()
+    assert res['success'] is True
+    assert 'height' in res
+
+
+def test_nethash():
+    res = ARK.block.nethash()
+    assert res['success'] is True
+    assert res['nethash'] == env.NETHASH
+
+
+def test_fee():
+    res = ARK.block.fee()
+    assert res['success'] is True
+    assert 'fee' in res
+
+
+def test_fees():
+    res = ARK.block.fees()
+    assert res['success'] is True
+    assert 'fees' in res
+
+
+def test_milestone():
+    res = ARK.block.milestone()
+    assert res['success'] is True
+    assert 'milestone' in res
+
+
+def test_reward():
+    res = ARK.block.reward()
+    assert res['success'] is True
+    assert 'reward' in res
+
+
+def test_supply():
+    res = ARK.block.supply()
+    assert res['success'] is True
+    assert 'supply' in res
+
+
+def test_status():
+    res = ARK.block.status()
+    assert res['success'] is True
+    assert 'epoch' in res
+    assert 'height' in res
+    assert 'fee' in res
+    assert 'milestone' in res
+    assert 'reward' in res
+    assert 'supply' in res
+    assert res['nethash'] == env.NETHASH

--- a/tests/api/one/test_block.py~
+++ b/tests/api/one/test_block.py~
@@ -1,0 +1,94 @@
+import test.api.one.env as env_v1
+import tests.env as env
+
+from ark.client import ArkClient
+
+
+ARK = ArkClient(
+    env.HOST,
+    env.PORT,
+    env.NETHASH,
+    env_v1.VERSION,
+    api_version=env_v1.API_VERSION
+)
+
+
+def test_block():
+    res = ARK.blocks().block(env.BLOCK_ID)
+    assert res['success'] is True
+    assert 'block' in res
+
+
+def test_blocks():
+    res = ARK.blocks().blocks()
+    assert res['success'] is True
+    assert 'blocks' in res
+    assert len(res['blocks']) == 100
+
+
+def test_blocks_with_parameters():
+    parameters = {'limit': 1}
+    res = ARK.blocks().blocks(parameters=parameters)
+    assert res['success'] is True
+    assert 'blocks' in res
+    assert len(res['blocks']) == 1
+
+
+def test_epoch():
+    res = ARK.blocks().epoch()
+    assert res['success'] is True
+    assert res['epoch'] == '2017-03-21T13:00:00.000Z'
+
+
+def test_height():
+    res = ARK.blocks().height()
+    assert res['success'] is True
+    assert 'height' in res
+
+
+def test_nethash():
+    res = ARK.blocks().nethash()
+    assert res['success'] is True
+    assert res['nethash'] == env.NETHASH
+
+
+def test_fee():
+    res = ARK.blocks().fee()
+    assert res['success'] is True
+    assert 'fee' in res
+
+
+def test_fees():
+    res = ARK.blocks().fees()
+    assert res['success'] is True
+    assert 'fees' in res
+
+
+def test_milestone():
+    res = ARK.blocks().milestone()
+    assert res['success'] is True
+    assert 'milestone' in res
+
+
+def test_reward():
+    res = ARK.blocks().reward()
+    assert res['success'] is True
+    assert 'reward' in res
+
+
+def test_supply():
+    res = ARK.blocks().supply()
+    assert res['success'] is True
+    assert 'supply' in res
+
+
+def test_status():
+    res = ARK.blocks().status()
+    assert res['success'] is True
+    assert 'epoch' in res
+    assert 'height' in res
+    assert 'fee' in res
+    assert 'milestone' in res
+    assert 'reward' in res
+    assert 'supply' in res
+    assert res['nethash'] == env.NETHASH

--- a/tests/api/one/test_delegate.py
+++ b/tests/api/one/test_delegate.py
@@ -1,0 +1,96 @@
+import pytest
+
+import tests.api.one.env as env_v1
+import tests.env as env
+
+from ark.client import ArkClient
+
+
+ARK = ArkClient(
+    env.HOST,
+    env.PORT,
+    env.NETHASH,
+    env_v1.VERSION,
+    api_version=env_v1.API_VERSION
+)
+
+
+def test_count():
+    res = ARK.delegate.count()
+    assert res['success'] is True
+    assert 'count' in res
+
+
+def test_search():
+    q = env.DELEGATE_NAME
+    res = ARK.delegate.search(q)
+    assert res['success'] is True
+    assert 'delegates' in res
+    assert len(res['delegates']) > 1
+
+
+def test_search_with_paremeters():
+    q = env.DELEGATE_NAME
+    parameters = {'limit': 1}
+    res = ARK.delegate.search(q, parameters=parameters)
+    assert res['success'] is True
+    assert 'delegates' in res
+    assert len(res['delegates']) == 1
+
+
+def test_voters():
+    res = ARK.delegate.voters(env.PUBLIC_KEY)
+    assert res['success'] is True
+    assert 'accounts' in res
+
+
+def test_delegate():
+    parameters = {'publicKey': env.PUBLIC_KEY}
+    res1 = ARK.delegate.delegate(parameters)
+    assert res1['success'] is True
+    assert 'delegate' in res1
+    parameters = {'username': env.DELEGATE_NAME}
+    res2 = ARK.delegate.delegate(parameters)
+    assert res1 == res2
+
+
+def test_delegates():
+    res = ARK.delegate.delegates()
+    assert res['success'] is True
+    assert 'delegates' in res
+    assert len(res['delegates']) == 51
+
+
+def test_delegates_with_paremeters():
+    parameters = {'limit': 1}
+    res = ARK.delegate.delegates(parameters=parameters)
+    assert res['success'] is True
+    assert 'delegates' in res
+    assert len(res['delegates']) == 1
+
+
+def test_fee():
+    res = ARK.delegate.fee()
+    assert res['success'] is True
+    assert 'fee' in res
+
+
+def test_forged_by_account():
+    res = ARK.delegate.forged_by_account(env.PUBLIC_KEY)
+    assert res['success'] is True
+    assert 'fees' in res
+    assert 'rewards' in res
+    assert 'forged' in res
+
+
+@pytest.mark.skip('Need to set up an account and add transaction testing.')
+def test_create():
+    assert False
+
+
+def test_next_forgers():
+    res = ARK.delegate.next_forgers()
+    assert res['success'] is True
+    assert 'currentBlock' in res
+    assert 'currentSlot' in res
+    assert 'delegates' in res

--- a/tests/api/one/test_delegate.py~
+++ b/tests/api/one/test_delegate.py~
@@ -1,0 +1,96 @@
+import pytest
+
+import tests.api.one.env as env_v1
+import tests.env as env
+
+from ark.client import ArkClient
+
+
+ARK = ArkClient(
+    env.HOST,
+    env.PORT,
+    env.NETHASH,
+    env_v1.VERSION,
+    api_version=env_v1.API_VERSION
+)
+
+
+def test_count():
+    res = ARK.delegates().count()
+    assert res['success'] is True
+    assert 'count' in res
+
+
+def test_search():
+    q = env.DELEGATE_NAME
+    res = ARK.delegates().search(q)
+    assert res['success'] is True
+    assert 'delegates' in res
+    assert len(res['delegates']) > 1
+
+
+def test_search_with_paremeters():
+    q = env.DELEGATE_NAME
+    parameters = {'limit': 1}
+    res = ARK.delegates().search(q, parameters=parameters)
+    assert res['success'] is True
+    assert 'delegates' in res
+    assert len(res['delegates']) == 1
+
+
+def test_voters():
+    res = ARK.delegates().voters(env.PUBLIC_KEY)
+    assert res['success'] is True
+    assert 'accounts' in res
+
+
+def test_delegate():
+    parameters = {'publicKey': env.PUBLIC_KEY}
+    res1 = ARK.delegates().delegate(parameters)
+    assert res1['success'] is True
+    assert 'delegate' in res1
+    parameters = {'username': env.DELEGATE_NAME}
+    res2 = ARK.delegates().delegate(parameters)
+    assert res1 == res2
+
+
+def test_delegates():
+    res = ARK.delegates().delegates()
+    assert res['success'] is True
+    assert 'delegates' in res
+    assert len(res['delegates']) == 51
+
+
+def test_delegates_with_paremeters():
+    parameters = {'limit': 1}
+    res = ARK.delegates().delegates(parameters=parameters)
+    assert res['success'] is True
+    assert 'delegates' in res
+    assert len(res['delegates']) == 1
+
+
+def test_fee():
+    res = ARK.delegates().fee()
+    assert res['success'] is True
+    assert 'fee' in res
+
+
+def test_forged_by_account():
+    res = ARK.delegates().forged_by_account(env.PUBLIC_KEY)
+    assert res['success'] is True
+    assert 'fees' in res
+    assert 'rewards' in res
+    assert 'forged' in res
+
+
+@pytest.mark.skip('Need to set up an account and add transaction testing.')
+def test_create():
+    assert False
+
+
+def test_next_forgers():
+    res = ARK.delegates().next_forgers()
+    assert res['success'] is True
+    assert 'currentBlock' in res
+    assert 'currentSlot' in res
+    assert 'delegates' in res

--- a/tests/api/one/test_loader.py
+++ b/tests/api/one/test_loader.py
@@ -1,0 +1,36 @@
+import tests.api.one.env as env_v1
+import tests.env as env
+
+from ark.client import ArkClient
+
+
+ARK = ArkClient(
+    env.HOST,
+    env.PORT,
+    env.NETHASH,
+    env_v1.VERSION,
+    api_version=env_v1.API_VERSION
+)
+
+
+def test_status():
+    res = ARK.loader.status()
+    assert res['success'] is True
+    assert 'loaded' in res
+    assert 'now' in res
+    assert 'blocksCount' in res
+
+
+def test_sync():
+    res = ARK.loader.sync()
+    assert res['success'] is True
+    assert 'syncing' in res
+    assert 'blocks' in res
+    assert 'height' in res
+    assert 'id' in res
+
+
+def test_autoconfigure():
+    res = ARK.loader.autoconfigure()
+    assert res['success'] is True
+    assert 'network' in res

--- a/tests/api/one/test_loader.py~
+++ b/tests/api/one/test_loader.py~
@@ -1,0 +1,36 @@
+import tests.api.one.env as env_v1
+import tests.env as env
+
+from ark.client import ArkClient
+
+
+ARK = ArkClient(
+    env.HOST,
+    env.PORT,
+    env.NETHASH,
+    env_v1.VERSION,
+    api_version=env_v1.API_VERSION
+)
+
+
+def test_status():
+    res = ARK.loaders().status()
+    assert res['success'] is True
+    assert 'loaded' in res
+    assert 'now' in res
+    assert 'blocksCount' in res
+
+
+def test_sync():
+    res = ARK.loaders().sync()
+    assert res['success'] is True
+    assert 'syncing' in res
+    assert 'blocks' in res
+    assert 'height' in res
+    assert 'id' in res
+
+
+def test_autoconfigure():
+    res = ARK.loaders().autoconfigure()
+    assert res['success'] is True
+    assert 'network' in res

--- a/tests/api/one/test_peer.py
+++ b/tests/api/one/test_peer.py
@@ -1,0 +1,46 @@
+import tests.api.one.env as env_v1
+import tests.env as env
+
+from ark.client import ArkClient
+
+
+ARK = ArkClient(
+    env.HOST,
+    env.PORT,
+    env.NETHASH,
+    env_v1.VERSION,
+    api_version=env_v1.API_VERSION
+)
+
+
+def test_peer():
+    ip = env.HOST
+    port = env.PORT
+    res = ARK.peers.peer(ip, port)
+    assert res['success'] is True
+    assert 'peer' in res
+    assert res['peer']['ip'] == ip
+    assert res['peer']['port'] == port
+    assert res['peer']['version'] == env_v1.VERSION
+
+
+def test_peers():
+    res = ARK.peers.peers()
+    assert res['success'] is True
+    assert 'peers' in res
+    assert len(res['peers']) > 1
+
+
+def test_peers_with_parameters():
+    parameters = {'status': 'OK'}
+    res = ARK.peers.peers(parameters)
+    assert res['success'] is True
+    assert 'peers' in res
+    statuses_are_ok = [peer['status'] == 'OK' for peer in res['peers']]
+    assert all(statuses_are_ok)
+
+
+def test_version():
+    res = ARK.peers.version()
+    assert res['success'] is True
+    assert res['version'] == env_v1.VERSION

--- a/tests/api/one/test_peer.py~
+++ b/tests/api/one/test_peer.py~
@@ -1,0 +1,46 @@
+import tests.api.one.env as env_v1
+import tests.env as env
+
+from ark.client import ArkClient
+
+
+ARK = ArkClient(
+    env.HOST,
+    env.PORT,
+    env.NETHASH,
+    env_v1.VERSION,
+    api_version=env_v1.API_VERSION
+)
+
+
+def test_peer():
+    ip = env.HOST
+    port = env.PORT
+    res = ARK.peer.peer(ip, port)
+    assert res['success'] is True
+    assert 'peer' in res
+    assert res['peer']['ip'] == ip
+    assert res['peer']['port'] == port
+    assert res['peer']['version'] == env_v1.VERSION
+
+
+def test_peers():
+    res = ARK.peer.peers()
+    assert res['success'] is True
+    assert 'peers' in res
+    assert len(res['peers']) > 1
+
+
+def test_peers_with_parameters():
+    parameters = {'status': 'OK'}
+    res = ARK.peer.peers(parameters)
+    assert res['success'] is True
+    assert 'peers' in res
+    statuses_are_ok = [peer['status'] == 'OK' for peer in res['peers']]
+    assert all(statuses_are_ok)
+
+
+def test_version():
+    res = ARK.peer.version()
+    assert res['success'] is True
+    assert res['version'] == env_v1.VERSION

--- a/tests/api/one/test_signature.py
+++ b/tests/api/one/test_signature.py
@@ -1,0 +1,26 @@
+import pytest
+
+import tests.api.one.env as env_v1
+import tests.env as env
+
+from ark.client import ArkClient
+
+
+ARK = ArkClient(
+    env.HOST,
+    env.PORT,
+    env.NETHASH,
+    env_v1.VERSION,
+    api_version=env_v1.API_VERSION
+)
+
+
+def test_fee():
+    res = ARK.signature.fee()
+    assert res['success'] is True
+    assert 'fee' in res
+
+
+@pytest.mark.skip('Need to set up an account and add transaction testing.')
+def test_create():
+    assert False

--- a/tests/api/one/test_signature.py~
+++ b/tests/api/one/test_signature.py~
@@ -1,0 +1,26 @@
+import pytest
+
+import tests.api.one.env as env_v1
+import tests.env as env
+
+from ark.client import ArkClient
+
+
+ARK = ArkClient(
+    env.HOST,
+    env.PORT,
+    env.NETHASH,
+    env_v1.VERSION,
+    api_version=env_v1.API_VERSION
+)
+
+
+def test_fee():
+    res = ARK.signatures().fee()
+    assert res['success'] is True
+    assert 'fee' in res
+
+
+@pytest.mark.skip('Need to set up an account and add transaction testing.')
+def test_create():
+    assert False

--- a/tests/api/one/test_transaction.py
+++ b/tests/api/one/test_transaction.py
@@ -1,0 +1,59 @@
+import pytest
+
+import tests.api.one.env as env_v1
+import tests.env as env
+
+from ark.client import ArkClient
+
+
+ARK = ArkClient(
+    env.HOST,
+    env.PORT,
+    env.NETHASH,
+    env_v1.VERSION,
+    api_version=env_v1.API_VERSION
+)
+
+
+def test_transaction():
+    res = ARK.transaction.transaction(env.TRANSACTION_ID)
+    assert res['success'] is True
+    assert 'transaction' in res
+
+
+def test_transactions():
+    res = ARK.transaction.transactions()
+    assert res['success'] is True
+    assert 'transactions' in res
+    assert len(res['transactions']) > 1
+
+
+def test_transactions_with_parameters():
+    parameters = {'limit': 1, 'offset': 0}
+    res = ARK.transaction.transactions(parameters)
+    assert res['success'] is True
+    assert 'transactions' in res
+    assert len(res['transactions']) == 1
+
+
+@pytest.mark.skip('Need to create transaction to test unconrfirmed transaction')
+def test_unconfirmed_transaction():
+    parameters = {'orderBy': 'timestamp:desc',
+                  'limit': 1}
+    res = ARK.transaction.transactions(parameters)
+    assert res['success'] is True
+    id_ = res['transactions'][0]['id']
+    res = ARK.transaction.unconfirmed_transaction(id_)
+    assert res['success'] is True
+    assert 'transaction' in res
+
+
+def test_unconfirmed_transactions():
+    res = ARK.transaction.unconfirmed_transactions()
+    assert res['success'] is True
+    assert 'transactions' in res
+
+
+@pytest.mark.skip('Need to set up an account and add transaction testing.')
+def test_create():
+    assert False

--- a/tests/api/one/test_transaction.py~
+++ b/tests/api/one/test_transaction.py~
@@ -1,0 +1,59 @@
+import pytest
+
+import tests.api.one.env as env_v1
+import tests.env as env
+
+from ark.client import ArkClient
+
+
+ARK = ArkClient(
+    env.HOST,
+    env.PORT,
+    env.NETHASH,
+    env_v1.VERSION,
+    api_version=env_v1.API_VERSION
+)
+
+
+def test_transaction():
+    res = ARK.transactions().transaction(env.TRANSACTION_ID)
+    assert res['success'] is True
+    assert 'transaction' in res
+
+
+def test_transactions():
+    res = ARK.transactions().transactions()
+    assert res['success'] is True
+    assert 'transactions' in res
+    assert len(res['transactions']) > 1
+
+
+def test_transactions_with_parameters():
+    parameters = {'limit': 1, 'offset': 0}
+    res = ARK.transactions().transactions(parameters)
+    assert res['success'] is True
+    assert 'transactions' in res
+    assert len(res['transactions']) == 1
+
+
+@pytest.mark.skip('Need to create transaction to test unconrfirmed transaction')
+def test_unconfirmed_transaction():
+    parameters = {'orderBy': 'timestamp:desc',
+                  'limit': 1}
+    res = ARK.transactions().transactions(parameters)
+    assert res['success'] is True
+    id_ = res['transactions'][0]['id']
+    res = ARK.transactions().unconfirmed_transaction(id_)
+    assert res['success'] is True
+    assert 'transaction' in res
+
+
+def test_unconfirmed_transactions():
+    res = ARK.transactions().unconfirmed_transactions()
+    assert res['success'] is True
+    assert 'transactions' in res
+
+
+@pytest.mark.skip('Need to set up an account and add transaction testing.')
+def test_create():
+    assert False

--- a/tests/api/one/test_transport.py
+++ b/tests/api/one/test_transport.py
@@ -1,0 +1,95 @@
+import pytest
+
+import tests.api.one.env as env_v1
+import tests.env as env
+
+from ark.client import ArkClient
+
+
+ARK = ArkClient(
+    env.HOST,
+    env.PORT,
+    env.NETHASH,
+    env_v1.VERSION,
+    api_version=env_v1.API_VERSION
+)
+
+
+def test_list():
+    res = ARK.transport.list()
+    assert res['success'] is True
+    assert 'peers' in res
+
+
+@pytest.mark.skip('Server returns Expected type string but found type integer: #/ids')
+def test_blocks_common():
+    ids = [env.BLOCK_ID]
+    res = ARK.transport.blocks_common(ids)
+    assert res['success'] is True
+    assert 'common' in res
+    assert 'lastBlockHeight' in res
+
+
+def test_blocks_common_multiple():
+    ids = [env.BLOCK_ID, env.NEXT_BLOCK_ID]
+    res = ARK.transport.blocks_common(ids)
+    assert res['success'] is True
+    assert 'common' in res
+    assert 'lastBlockHeight' in res
+
+
+@pytest.mark.skip('Server not returning "success" obj in JSON.')
+def test_block():
+    res = ARK.transport.block(env.BLOCK_ID)
+    assert res['success'] is True
+    assert 'block' in res
+
+
+def test_blocks():
+    res = ARK.transport.blocks()
+    assert res['success'] is True
+    assert 'blocks' in res
+
+
+@pytest.mark.skip('Need to set up an account and add transaction testing.')
+def test_create_block():
+    assert False
+
+
+def test_transactions():
+    res = ARK.transport.transactions()
+    assert res['success'] is True
+    assert 'transactions' in res
+
+
+def test_transactions_from_ids():
+    ids = [env.TRANSACTION_ID]
+    res = ARK.transport.transactions_from_ids(ids)
+    assert res['success'] is True
+    assert 'transactions' in res
+
+
+@pytest.mark.skip('Need to set up an account and add transaction testing.')
+def test_create_transaction():
+    assert False
+
+
+@pytest.mark.skip('Need to set up an account and add transaction testing.')
+def test_create_batch_transaction():
+    assert False
+
+
+def test_height():
+    res = ARK.transport.height()
+    assert res['success'] is True
+    assert 'height' in res
+    assert 'header' in res
+
+
+def test_status():
+    res = ARK.transport.status()
+    assert res['success'] is True
+    assert 'height' in res
+    assert 'forgingAllowed' in res
+    assert 'currentSlot' in res
+    assert 'header' in res

--- a/tests/api/one/test_transport.py~
+++ b/tests/api/one/test_transport.py~
@@ -1,0 +1,95 @@
+import pytest
+
+import tests.api.one.env as env_v1
+import tests.env as env
+
+from ark.client import ArkClient
+
+
+ARK = ArkClient(
+    env.HOST,
+    env.PORT,
+    env.NETHASH,
+    env_v1.VERSION,
+    api_version=env_v1.API_VERSION
+)
+
+
+def test_list():
+    res = ARK.transport().list()
+    assert res['success'] is True
+    assert 'peers' in res
+
+
+@pytest.mark.skip('Server returns Expected type string but found type integer: #/ids')
+def test_blocks_common():
+    ids = [env.BLOCK_ID]
+    res = ARK.transport().blocks_common(ids)
+    assert res['success'] is True
+    assert 'common' in res
+    assert 'lastBlockHeight' in res
+
+
+def test_blocks_common_multiple():
+    ids = [env.BLOCK_ID, env.NEXT_BLOCK_ID]
+    res = ARK.transport().blocks_common(ids)
+    assert res['success'] is True
+    assert 'common' in res
+    assert 'lastBlockHeight' in res
+
+
+@pytest.mark.skip('Server not returning "success" obj in JSON.')
+def test_block():
+    res = ARK.transport().block(env.BLOCK_ID)
+    assert res['success'] is True
+    assert 'block' in res
+
+
+def test_blocks():
+    res = ARK.transport().blocks()
+    assert res['success'] is True
+    assert 'blocks' in res
+
+
+@pytest.mark.skip('Need to set up an account and add transaction testing.')
+def test_create_block():
+    assert False
+
+
+def test_transactions():
+    res = ARK.transport().transactions()
+    assert res['success'] is True
+    assert 'transactions' in res
+
+
+def test_transactions_from_ids():
+    ids = [env.TRANSACTION_ID]
+    res = ARK.transport().transactions_from_ids(ids)
+    assert res['success'] is True
+    assert 'transactions' in res
+
+
+@pytest.mark.skip('Need to set up an account and add transaction testing.')
+def test_create_transaction():
+    assert False
+
+
+@pytest.mark.skip('Need to set up an account and add transaction testing.')
+def test_create_batch_transaction():
+    assert False
+
+
+def test_height():
+    res = ARK.transport().height()
+    assert res['success'] is True
+    assert 'height' in res
+    assert 'header' in res
+
+
+def test_status():
+    res = ARK.transport().status()
+    assert res['success'] is True
+    assert 'height' in res
+    assert 'forgingAllowed' in res
+    assert 'currentSlot' in res
+    assert 'header' in res

--- a/tests/api/one/test_vote.py
+++ b/tests/api/one/test_vote.py
@@ -1,0 +1,25 @@
+import pytest
+
+import tests.api.one.env as env_v1
+import tests.env as env
+
+from ark.client import ArkClient
+
+
+ARK = ArkClient(
+    env.HOST,
+    env.PORT,
+    env.NETHASH,
+    env_v1.VERSION,
+    api_version=env_v1.API_VERSION
+)
+
+
+@pytest.mark.skip('Need to set up an account and add transaction testing.')
+def test_vote():
+    assert False
+
+
+@pytest.mark.skip('Need to set up an account and add transaction testing.')
+def test_unvote():
+    assert False

--- a/tests/env.py
+++ b/tests/env.py
@@ -1,0 +1,18 @@
+HOST = '167.114.29.32'
+PORT = 4002
+NETHASH = '578e820911f24e039733b45e4882b73e301f813a0d2c31330dafda84534ffa23'
+
+DELEGATE_NAME = 'darkjarunik'
+
+# Jarunik's devnet address for testing
+ADDRESS = 'DBi2HdDY8TqMCD2aFLVomEF92gzeDmEHmR'
+
+# Jarunik's devnet public key for testing
+PUBLIC_KEY = '03bd4f16e39aaba5cba6a87b7498b08ce540f279be367e68ae96fb05dfabe203ad'
+
+# Block IDs for testing
+BLOCK_ID = '8249345846327363198'
+NEXT_BLOCK_ID = '18105265935060883326'
+
+# Transaction ID for testing
+TRANSACTION_ID = '4728249fec8363750d3b90d47c39daf78428aa95dbf90a49ebef9f7934779625'

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -1,3 +1,0 @@
-
-def test_dummy():
-    assert True is True


### PR DESCRIPTION
Here's the tests from my original PR refactored. It supports the new layout and the tests directory structure was updated based on @roks0n's comment.

Coveraged dropped to 81% but these are only the original tests refactored for the new layout.
```
ark/__init__.py                  1      0   100%
ark/api/one/__init__.py          0      0   100%
ark/api/one/account.py          18      4    78%
ark/api/one/block.py            24      0   100%
ark/api/one/delegate.py         23      1    96%
ark/api/one/loader.py            8      0   100%
ark/api/one/peers.py             8      0   100%
ark/api/one/signature.py         6      1    83%
ark/api/one/transaction.py      12      2    83%
ark/api/one/transport.py        27      4    85%
ark/api/one/vote.py              6      2    67%
ark/api/resource.py             13      4    69%
ark/client.py                   26      1    96%
ark/connection.py               74     27    64%
------------------------------------------------
TOTAL                          246     46    81%

```

There are 7 failures in transport with the error `AttributeError: 'Transport' object has no attribute 'connection'`.  I might need to set up the test differently now.
 