### PR TITLE
misc: add __init__.py to api directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 0.1.1 - 2018-08-28
+### Fixed
+- Added `__init__.py` to the api directory in order to include the api into the package
+
 ## 0.1.0 - 2018-08-27
 - Initial Release

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup_requires = ['pytest-runner'] if {'pytest', 'test', 'ptr'}.intersection(sys
 setuptools.setup(
     name='arkecosystem-client',
     description='A simple Python API client for the ARK Blockchain.',
-    version='0.1.0',
+    version='0.1.1',
     author='Ark Ecosystem',
     author_email='info@ark.io',
     url='https://github.com/ArkEcosystem/python-client',


### PR DESCRIPTION
## Proposed changes

Not having `__init__.py` in the api directory results in api directory to not be included in the package. I've tested this locally as well by building it and noticed the api directory was present after this change.

Also bumping the client version so it can get built and uploaded to pypi.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [x] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

None