### PR TITLE
fix: Use urllib instead of os.path for HTTP URLs

### DIFF
--- a/client/connection.py
+++ b/client/connection.py
@@ -1,4 +1,4 @@
-import os.path
+import urllib.parse
 
 import requests
 
@@ -20,7 +20,7 @@ class Connection(object):
         })
 
     def _build_url(self, path):
-        return os.path.join(self.hostname, path)
+        return urllib.parse.urljoin(self.hostname, path)
 
     def _handle_response(self, response):
         if not response.content:


### PR DESCRIPTION
## Proposed changes
Uses the unambiguous `urllib.parse` to construct HTTP URLs, in place of `os.path.join`.

Resolves #49 

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
_Not familiar with the linter used for this project. Where can I find more info on this?_
- [x] I have added tests that prove my fix is effective or that my feature works
_The current set of unit tests is sufficient to verify the URLs are still built correctly_