### PR TITLE
feat: support query parameters for blocks list endpoint

### DIFF
--- a/client/api/one/blocks.py
+++ b/client/api/one/blocks.py
@@ -7,14 +7,22 @@ class Blocks(Resource):
     def get(self, block_id):
         return self.request_get('blocks/get', {'id': block_id})
 
-    def all(self, limit=20, offset=None, **kwargs):
+    def all(self, limit=20, offset=None, order_by=None, height=None, previous_block=None, number_of_transactions=None,
+            total_amount=None, total_fee=None, reward=None, payload_hash=None, generator_public_key=None):
         if limit > 100:
             raise ArkParameterException('Maximum number of objects to return is 100')
-        extra_params = {name: kwargs[name] for name in kwargs if kwargs[name] is not None}
         params = {
             'limit': limit,
             'offset': offset,
-            **extra_params
+            'orderBy': order_by,
+            'height': height,
+            'previousBlock': previous_block,
+            'numberOfTransactions': number_of_transactions,
+            'totalAmount': total_amount,
+            'totalFee': total_fee,
+            'reward': reward,
+            'payloadHash': payload_hash,
+            'generatorPublicKey': generator_public_key,
         }
         return self.request_get('blocks', params)
 

--- a/client/api/one/blocks.py
+++ b/client/api/one/blocks.py
@@ -7,12 +7,14 @@ class Blocks(Resource):
     def get(self, block_id):
         return self.request_get('blocks/get', {'id': block_id})
 
-    def all(self, limit=20, offset=None):
+    def all(self, limit=20, offset=None, **kwargs):
         if limit > 100:
             raise ArkParameterException('Maximum number of objects to return is 100')
+        extra_params = {name: kwargs[name] for name in kwargs if kwargs[name] is not None}
         params = {
             'limit': limit,
             'offset': offset,
+            **extra_params
         }
         return self.request_get('blocks', params)
 

--- a/tests/api/one/test_blocks.py
+++ b/tests/api/one/test_blocks.py
@@ -50,6 +50,25 @@ def test_all_calls_correct_url_with_passed_in_params():
     assert 'offset=123' in responses.calls[0].request.url
 
 
+def test_all_calls_correct_url_with_additional_params():
+    responses.add(
+      responses.GET,
+      'http://127.0.0.1:4002/blocks',
+      json={'success': True},
+      status=200
+    )
+
+    client = ArkClient('http://127.0.0.1:4002', api_version='v1')
+    client.blocks.all(limit=20, orderBy="timestamp", numberOfTransactions=5)
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url.startswith(
+      'http://127.0.0.1:4002/blocks?'
+    )
+    assert 'limit=20' in responses.calls[0].request.url
+    assert 'orderBy=timestamp' in responses.calls[0].request.url
+    assert 'numberOfTransactions=5' in responses.calls[0].request.url
+
+
 def test_epoch_calls_correct_url():
     responses.add(
         responses.GET,

--- a/tests/api/one/test_blocks.py
+++ b/tests/api/one/test_blocks.py
@@ -59,7 +59,7 @@ def test_all_calls_correct_url_with_additional_params():
     )
 
     client = ArkClient('http://127.0.0.1:4002', api_version='v1')
-    client.blocks.all(limit=20, orderBy="timestamp", numberOfTransactions=5)
+    client.blocks.all(limit=20, order_by="timestamp", number_of_transactions=5)
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith(
       'http://127.0.0.1:4002/blocks?'


### PR DESCRIPTION
## Proposed changes

It is now possible to use every parameters for the /blocks/ endpoint for the V1 API. These parameters weren't listed on the [official documentation](https://docs.ark.io/api/public/v1/blocks.html#list-all-blocks) but I tested it and it works, so with that it's possible to use parameters like orderBy for the blocks.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Test (adding missing tests or fixing existing tests)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works