### PR TITLE
fix: add Content-Type into the headers

### DIFF
--- a/client/connection.py
+++ b/client/connection.py
@@ -48,6 +48,7 @@ class Connection(object):
 
         self.session.headers.update({
             'port': '1',
+            'Content-Type': 'application/json',
             'API-Version': api_version_number
         })
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -13,6 +13,7 @@ def test_connection_creation_sets_default_session_headers_and_variables():
     assert connection.hostname == 'http://127.0.0.1:4003'
     assert isinstance(connection.session, requests.Session)
     assert connection.session.headers['port'] == '1'
+    assert connection.session.headers['Content-Type'] == 'application/json'
     assert connection.session.headers['API-Version'] == '2'
 
 


### PR DESCRIPTION
## Proposed changes

Added `Content-Type: application/json` to the headers of the connection class.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works