### PR TITLE
fix: Modified the limit parameter, updated the tests for the V2

### DIFF
--- a/client/api/two/blocks.py
+++ b/client/api/two/blocks.py
@@ -3,7 +3,7 @@ from client.resource import Resource
 
 class Blocks(Resource):
 
-    def all(self, page=None, limit=20):
+    def all(self, page=None, limit=100):
         params = {
             'page': page,
             'limit': limit,
@@ -13,14 +13,14 @@ class Blocks(Resource):
     def get(self, block_id):
         return self.request_get('blocks/{}'.format(block_id))
 
-    def transactions(self, block_id, page=None, limit=20):
+    def transactions(self, block_id, page=None, limit=100):
         params = {
             'page': page,
             'limit': limit,
         }
         return self.request_get('blocks/{}/transactions'.format(block_id), params)
 
-    def search(self, criteria, page=None, limit=20):
+    def search(self, criteria, page=None, limit=100):
         params = {
             'page': page,
             'limit': limit,

--- a/client/api/two/delegates.py
+++ b/client/api/two/delegates.py
@@ -3,7 +3,7 @@ from client.resource import Resource
 
 class Delegates(Resource):
 
-    def all(self, page=None, limit=20):
+    def all(self, page=None, limit=100):
         params = {
             'page': page,
             'limit': limit,
@@ -13,21 +13,21 @@ class Delegates(Resource):
     def get(self, delegate_id):
         return self.request_get('delegates/{}'.format(delegate_id))
 
-    def search(self, username, page=None, limit=20):
+    def search(self, username, page=None, limit=100):
         params = {
             'page': page,
             'limit': limit,
         }
         return self.request_post('delegates/search', data={'username': username}, params=params)
 
-    def blocks(self, delegate_id, page=None, limit=20):
+    def blocks(self, delegate_id, page=None, limit=100):
         params = {
             'page': page,
             'limit': limit,
         }
         return self.request_get('delegates/{}/blocks'.format(delegate_id), params)
 
-    def voters(self, delegate_id, page=None, limit=20):
+    def voters(self, delegate_id, page=None, limit=100):
         params = {
             'page': page,
             'limit': limit,

--- a/client/api/two/peers.py
+++ b/client/api/two/peers.py
@@ -4,7 +4,7 @@ from client.resource import Resource
 class Peers(Resource):
 
     def all(self, os=None, status=None, port=None, version=None, order_by=None,
-            page=None, limit=20):
+            page=None, limit=100):
 
         params = {
             'os': os,

--- a/client/api/two/transactions.py
+++ b/client/api/two/transactions.py
@@ -3,7 +3,7 @@ from client.resource import Resource
 
 class Transactions(Resource):
 
-    def all(self, page=None, limit=20):
+    def all(self, page=None, limit=100):
         params = {
             'page': page,
             'limit': limit,
@@ -16,7 +16,7 @@ class Transactions(Resource):
     def get(self, transaction_id):
         return self.request_get('transactions/{}'.format(transaction_id))
 
-    def all_unconfirmed(self, limit=20, offset=None):
+    def all_unconfirmed(self, limit=100, offset=None):
         params = {
             'limit': limit,
             'offset': offset,
@@ -26,7 +26,7 @@ class Transactions(Resource):
     def get_unconfirmed(self, transaction_id):
         return self.request_get('transactions/unconfirmed/{}'.format(transaction_id))
 
-    def search(self, criteria, page=None, limit=20):
+    def search(self, criteria, page=None, limit=100):
         params = {
             'page': page,
             'limit': limit,

--- a/client/api/two/votes.py
+++ b/client/api/two/votes.py
@@ -3,7 +3,7 @@ from client.resource import Resource
 
 class Votes(Resource):
 
-    def all(self, page=None, limit=20):
+    def all(self, page=None, limit=100):
         params = {
             'page': page,
             'limit': limit,

--- a/client/api/two/wallets.py
+++ b/client/api/two/wallets.py
@@ -3,14 +3,14 @@ from client.resource import Resource
 
 class Wallets(Resource):
 
-    def all(self, page=None, limit=20):
+    def all(self, page=None, limit=100):
         params = {
             'page': page,
             'limit': limit,
         }
         return self.request_get('wallets', params)
 
-    def top(self, page=None, limit=20):
+    def top(self, page=None, limit=100):
         params = {
             'page': page,
             'limit': limit
@@ -20,35 +20,35 @@ class Wallets(Resource):
     def get(self, wallet_id):
         return self.request_get('wallets/{}'.format(wallet_id))
 
-    def transactions(self, wallet_id, page=None, limit=20):
+    def transactions(self, wallet_id, page=None, limit=100):
         params = {
             'page': page,
             'limit': limit,
         }
         return self.request_get('wallets/{}/transactions'.format(wallet_id), params)
 
-    def transactions_sent(self, wallet_id, page=None, limit=20):
+    def transactions_sent(self, wallet_id, page=None, limit=100):
         params = {
             'page': page,
             'limit': limit,
         }
         return self.request_get('wallets/{}/transactions/sent'.format(wallet_id), params)
 
-    def transactions_received(self, wallet_id, page=None, limit=20):
+    def transactions_received(self, wallet_id, page=None, limit=100):
         params = {
             'page': page,
             'limit': limit,
         }
         return self.request_get('wallets/{}/transactions/received'.format(wallet_id), params)
 
-    def votes(self, wallet_id, page=None, limit=20):
+    def votes(self, wallet_id, page=None, limit=100):
         params = {
             'page': page,
             'limit': limit,
         }
         return self.request_get('wallets/{}/votes'.format(wallet_id), params)
 
-    def search(self, criteria, page=None, limit=20):
+    def search(self, criteria, page=None, limit=100):
         params = {
             'page': page,
             'limit': limit,

--- a/tests/api/two/test_blocks.py
+++ b/tests/api/two/test_blocks.py
@@ -16,7 +16,7 @@ def test_all_calls_correct_url_with_default_params():
     client = ArkClient('http://127.0.0.1:4002', api_version='v2')
     client.blocks.all()
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/blocks?limit=20'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/blocks?limit=100'
 
 
 def test_all_calls_correct_url_with_passed_in_params():
@@ -64,7 +64,7 @@ def test_transactions_calls_correct_url_with_default_params():
     client.blocks.transactions(block_id)
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == (
-        'http://127.0.0.1:4002/blocks/12345/transactions?limit=20'
+        'http://127.0.0.1:4002/blocks/12345/transactions?limit=100'
     )
 
 
@@ -98,7 +98,7 @@ def test_search_calls_correct_url_with_default_params():
     client = ArkClient('http://127.0.0.1:4002', api_version='v2')
     client.blocks.search({'previousBlock': '1337'})
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/blocks/search?limit=20'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/blocks/search?limit=100'
     assert json.loads(responses.calls[0].request.body.decode()) == {'previousBlock': '1337'}
 
 

--- a/tests/api/two/test_delegates.py
+++ b/tests/api/two/test_delegates.py
@@ -16,7 +16,7 @@ def test_all_calls_correct_url_with_default_params():
     client = ArkClient('http://127.0.0.1:4002', api_version='v2')
     client.delegates.all()
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/delegates?limit=20'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/delegates?limit=100'
 
 
 def test_all_calls_correct_url_with_passed_in_params():
@@ -62,7 +62,7 @@ def test_search_calls_correct_url_with_default_params():
     client = ArkClient('http://127.0.0.1:4002', api_version='v2')
     client.delegates.search('deadlock')
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/delegates/search?limit=20'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/delegates/search?limit=100'
     assert json.loads(responses.calls[0].request.body.decode()) == {'username': 'deadlock'}
 
 
@@ -96,7 +96,7 @@ def test_blocks_calls_correct_url_with_default_params():
     client.delegates.blocks(delegate_id)
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == (
-        'http://127.0.0.1:4002/delegates/12345/blocks?limit=20'
+        'http://127.0.0.1:4002/delegates/12345/blocks?limit=100'
     )
 
 
@@ -132,7 +132,7 @@ def test_voters_calls_correct_url_with_default_params():
     client.delegates.voters(delegate_id)
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == (
-        'http://127.0.0.1:4002/delegates/12345/voters?limit=20'
+        'http://127.0.0.1:4002/delegates/12345/voters?limit=100'
     )
 
 

--- a/tests/api/two/test_peers.py
+++ b/tests/api/two/test_peers.py
@@ -14,7 +14,7 @@ def test_all_calls_correct_url_with_default_params():
     client = ArkClient('http://127.0.0.1:4002', api_version='v2')
     client.peers.all()
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/peers?limit=20'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/peers?limit=100'
 
 
 def test_all_calls_correct_url_with_passed_in_params():

--- a/tests/api/two/test_transactions.py
+++ b/tests/api/two/test_transactions.py
@@ -16,7 +16,7 @@ def test_all_calls_correct_url_with_default_params():
     client = ArkClient('http://127.0.0.1:4002', api_version='v2')
     client.transactions.all()
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/transactions?limit=20'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/transactions?limit=100'
 
 
 def test_all_calls_correct_url_with_passed_in_params():
@@ -80,7 +80,7 @@ def test_all_unconfirmed_calls_correct_url_with_default_params():
     client.transactions.all_unconfirmed()
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == (
-        'http://127.0.0.1:4002/transactions/unconfirmed?limit=20'
+        'http://127.0.0.1:4002/transactions/unconfirmed?limit=100'
     )
 
 
@@ -113,7 +113,7 @@ def test_search_calls_correct_url_with_default_params():
     client = ArkClient('http://127.0.0.1:4002', api_version='v2')
     client.transactions.search({'blockId': '1337'})
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/transactions/search?limit=20'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/transactions/search?limit=100'
     assert json.loads(responses.calls[0].request.body.decode()) == {'blockId': '1337'}
 
 

--- a/tests/api/two/test_votes.py
+++ b/tests/api/two/test_votes.py
@@ -14,7 +14,7 @@ def test_all_calls_correct_url_with_default_params():
     client = ArkClient('http://127.0.0.1:4002', api_version='v2')
     client.votes.all()
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/votes?limit=20'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/votes?limit=100'
 
 
 def test_all_calls_correct_url_with_passed_in_params():

--- a/tests/api/two/test_wallets.py
+++ b/tests/api/two/test_wallets.py
@@ -4,6 +4,7 @@ import responses
 
 from client import ArkClient
 
+
 def test_all_calls_correct_url_with_default_params():
     responses.add(
         responses.GET,
@@ -15,7 +16,7 @@ def test_all_calls_correct_url_with_default_params():
     client = ArkClient('http://127.0.0.1:4002', api_version='v2')
     client.wallets.all()
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/wallets?limit=20'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/wallets?limit=100'
 
 
 def test_all_calls_correct_url_with_passed_in_params():
@@ -45,7 +46,7 @@ def test_top_calls_correct_url_with_default_params():
     client = ArkClient('http://127.0.0.1:4002', api_version='v2')
     client.wallets.top()
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/wallets/top?limit=20'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/wallets/top?limit=100'
 
 
 def test_top_calls_correct_url_with_passed_in_params():
@@ -93,7 +94,7 @@ def test_transactions_calls_correct_url_with_default_params():
     client.wallets.transactions(wallet_id)
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == (
-        'http://127.0.0.1:4002/wallets/12345/transactions?limit=20'
+        'http://127.0.0.1:4002/wallets/12345/transactions?limit=100'
     )
 
 
@@ -129,7 +130,7 @@ def test_transactions_sent_calls_correct_url_with_default_params():
     client.wallets.transactions_sent(wallet_id)
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == (
-        'http://127.0.0.1:4002/wallets/12345/transactions/sent?limit=20'
+        'http://127.0.0.1:4002/wallets/12345/transactions/sent?limit=100'
     )
 
 
@@ -165,7 +166,7 @@ def test_transactions_received_calls_correct_url_with_default_params():
     client.wallets.transactions_received(wallet_id)
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == (
-        'http://127.0.0.1:4002/wallets/12345/transactions/received?limit=20'
+        'http://127.0.0.1:4002/wallets/12345/transactions/received?limit=100'
     )
 
 
@@ -201,7 +202,7 @@ def test_votes_calls_correct_url_with_default_params():
     client.wallets.votes(wallet_id)
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == (
-        'http://127.0.0.1:4002/wallets/12345/votes?limit=20'
+        'http://127.0.0.1:4002/wallets/12345/votes?limit=100'
     )
 
 
@@ -235,7 +236,7 @@ def test_search_calls_correct_url_with_default_params():
     client = ArkClient('http://127.0.0.1:4002', api_version='v2')
     client.wallets.search({'address': 'my-address'})
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/wallets/search?limit=20'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/wallets/search?limit=100'
     assert json.loads(responses.calls[0].request.body.decode()) == {'address': 'my-address'}
 
 


### PR DESCRIPTION
## Proposed changes

Updated the limit parameter everywhere where it was used in the code for the v2 client. The reasoning behind these changes is the fact that the default limit value when you query the API without passing parameters is set to 100, which makes it quite confusing here with the default being previously set to 20. With this change, the default value of the limit parameter will be the same as when using the API by default.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works