### PR TITLE
fix: Modified the limit parameter, updated the tests for the V1

### DIFF
--- a/client/api/one/accounts.py
+++ b/client/api/one/accounts.py
@@ -19,7 +19,7 @@ class Accounts(Resource):
     def get(self, address):
         return self.request_get('accounts', {'address': address})
 
-    def all(self, limit=20, offset=None):
+    def all(self, limit=100, offset=None):
         if limit > 100:
             raise ArkParameterException('Maximum number of objects to return is 100')
         params = {
@@ -28,7 +28,7 @@ class Accounts(Resource):
         }
         return self.request_get('accounts/getAllAccounts', params)
 
-    def top(self, limit=20, offset=None):
+    def top(self, limit=100, offset=None):
         if limit > 100:
             raise ArkParameterException('Maximum number of objects to return is 100')
         params = {

--- a/client/api/one/blocks.py
+++ b/client/api/one/blocks.py
@@ -7,7 +7,7 @@ class Blocks(Resource):
     def get(self, block_id):
         return self.request_get('blocks/get', {'id': block_id})
 
-    def all(self, limit=20, offset=None, order_by=None, height=None, previous_block=None, number_of_transactions=None,
+    def all(self, limit=100, offset=None, order_by=None, height=None, previous_block=None, number_of_transactions=None,
             total_amount=None, total_fee=None, reward=None, payload_hash=None, generator_public_key=None):
         if limit > 100:
             raise ArkParameterException('Maximum number of objects to return is 100')

--- a/client/api/one/delegates.py
+++ b/client/api/one/delegates.py
@@ -7,7 +7,7 @@ class Delegate(Resource):
     def count(self):
         return self.request_get('delegates/count')
 
-    def search(self, query, limit=20, offset=None):
+    def search(self, query, limit=100, offset=None):
         if limit > 100:
             raise ArkParameterException('Maximum number of objects to return is 100')
         params = {
@@ -30,9 +30,9 @@ class Delegate(Resource):
         }
         return self.request_get('delegates/get', params)
 
-    def all(self, limit=20, offset=None, order_by=None):
+    def all(self, limit=51, offset=None, order_by=None):
         if limit > 100:
-            raise ArkParameterException('Maximum number of objects to return is 100')
+            raise ArkParameterException('Maximum number of objects to return is 51')
 
         params = {
             'limit': limit,

--- a/client/api/one/peers.py
+++ b/client/api/one/peers.py
@@ -11,7 +11,7 @@ class Peers(Resource):
         }
         return self.request_get('peers/get', params)
 
-    def all(self, limit=20, offset=None):
+    def all(self, limit=100, offset=None):
         if limit > 100:
             raise ArkParameterException('Maximum number of objects to return is 100')
         params = {

--- a/client/api/one/transactions.py
+++ b/client/api/one/transactions.py
@@ -7,7 +7,7 @@ class Transactions(Resource):
     def get(self, transaction_id):
         return self.request_get('transactions/get', {'id': transaction_id})
 
-    def all(self, limit=20, offset=None, block_id=None, type=None, order_by=None, sender_public_key=None,
+    def all(self, limit=100, offset=None, block_id=None, type=None, order_by=None, sender_public_key=None,
             vendor_field=None, owner_public_key=None, owner_address=None, sender_id=None, recipient_id=None,
             amount=None, fee=None):
         if limit > 100:
@@ -32,7 +32,7 @@ class Transactions(Resource):
     def get_unconfirmed(self, transaction_id):
         return self.request_get('transactions/unconfirmed/get', {'id': transaction_id})
 
-    def all_unconfirmed(self, limit=20, offset=None):
+    def all_unconfirmed(self, limit=100, offset=None):
         if limit > 100:
             raise ArkParameterException('Maximum number of objects to return is 100')
         params = {

--- a/tests/api/one/test_accounts.py
+++ b/tests/api/one/test_accounts.py
@@ -92,7 +92,7 @@ def test_all_calls_correct_url_with_default_params():
     client.accounts.all()
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == (
-        'http://127.0.0.1:4002/accounts/getAllAccounts?limit=20'
+        'http://127.0.0.1:4002/accounts/getAllAccounts?limit=100'
     )
 
 
@@ -125,7 +125,7 @@ def test_top_calls_correct_url_with_default_params():
     client = ArkClient('http://127.0.0.1:4002', api_version='v1')
     client.accounts.top()
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/accounts/top?limit=20'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/accounts/top?limit=100'
 
 
 def test_top_calls_correct_url_with_passed_in_params():

--- a/tests/api/one/test_blocks.py
+++ b/tests/api/one/test_blocks.py
@@ -31,7 +31,7 @@ def test_all_calls_correct_url_with_default_params():
     client = ArkClient('http://127.0.0.1:4002', api_version='v1')
     client.blocks.all()
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/blocks?limit=20'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/blocks?limit=100'
 
 
 def test_all_calls_correct_url_with_passed_in_params():

--- a/tests/api/one/test_delegates.py
+++ b/tests/api/one/test_delegates.py
@@ -31,7 +31,7 @@ def test_search_calls_correct_url_with_default_params():
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith('http://127.0.0.1:4002/delegates/search?')
     assert 'q=my-query' in responses.calls[0].request.url
-    assert 'limit=20' in responses.calls[0].request.url
+    assert 'limit=100' in responses.calls[0].request.url
 
 
 def test_search_calls_correct_url_with_passed_in_params():
@@ -94,7 +94,7 @@ def test_all_calls_correct_url_with_default_params():
     client = ArkClient('http://127.0.0.1:4002', api_version='v1')
     client.delegates.all()
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/delegates?limit=20'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/delegates?limit=51'
 
 
 def test_all_calls_correct_url_with_passed_in_params():

--- a/tests/api/one/test_peers.py
+++ b/tests/api/one/test_peers.py
@@ -31,7 +31,7 @@ def test_all_calls_correct_url_with_default_params():
     client = ArkClient('http://127.0.0.1:4002', api_version='v1')
     client.peers.all()
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/peers?limit=20'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/peers?limit=100'
 
 
 def test_all_calls_correct_url_with_passed_in_params():

--- a/tests/api/one/test_transactions.py
+++ b/tests/api/one/test_transactions.py
@@ -31,7 +31,7 @@ def test_all_calls_correct_url_with_default_params():
     client = ArkClient('http://127.0.0.1:4002', api_version='v1')
     client.transactions.all()
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/transactions?limit=20'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/transactions?limit=100'
 
 
 def test_all_calls_correct_url_with_passed_in_params():
@@ -101,7 +101,7 @@ def test_all_unconfirmed_calls_correct_url_with_default_params():
     client.transactions.all_unconfirmed()
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == (
-        'http://127.0.0.1:4002/transactions/unconfirmed?limit=20'
+        'http://127.0.0.1:4002/transactions/unconfirmed?limit=100'
     )
 
 


### PR DESCRIPTION
## Proposed changes
Following of the previous PR, but for the V1.

Updated the limit parameter everywhere where it was used in the code for the v1 client. The reasoning behind these changes is the fact that the default limit value when you query the API without passing parameters is set to 100, which makes it quite confusing here with the default being previously set to 20. With this change, the default value of the limit parameter will be the same as when using the API by default.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works