### PR TITLE
feat: support query parameters for every possible methods

### DIFF
--- a/client/api/blocks.py
+++ b/client/api/blocks.py
@@ -3,10 +3,12 @@ from client.resource import Resource
 
 class Blocks(Resource):
 
-    def all(self, page=None, limit=100):
+    def all(self, page=None, limit=100, **kwargs):
+        extra_params = {name: kwargs[name] for name in kwargs if kwargs[name] is not None}
         params = {
             'page': page,
             'limit': limit,
+            **extra_params
         }
         return self.request_get('blocks', params)
 

--- a/client/api/delegates.py
+++ b/client/api/delegates.py
@@ -3,10 +3,12 @@ from client.resource import Resource
 
 class Delegates(Resource):
 
-    def all(self, page=None, limit=100):
+    def all(self, page=None, limit=100, **kwargs):
+        extra_params = {name: kwargs[name] for name in kwargs if kwargs[name] is not None}
         params = {
             'page': page,
             'limit': limit,
+            **extra_params
         }
         return self.request_get('delegates', params)
 

--- a/client/api/transactions.py
+++ b/client/api/transactions.py
@@ -3,10 +3,12 @@ from client.resource import Resource
 
 class Transactions(Resource):
 
-    def all(self, page=None, limit=100):
+    def all(self, page=None, limit=100, **kwargs):
+        extra_params = {name: kwargs[name] for name in kwargs if kwargs[name] is not None}
         params = {
             'page': page,
             'limit': limit,
+            **extra_params
         }
         return self.request_get('transactions', params)
 
@@ -16,10 +18,12 @@ class Transactions(Resource):
     def get(self, transaction_id):
         return self.request_get('transactions/{}'.format(transaction_id))
 
-    def all_unconfirmed(self, limit=100, offset=None):
+    def all_unconfirmed(self, limit=100, offset=None, **kwargs):
+        extra_params = {name: kwargs[name] for name in kwargs if kwargs[name] is not None}
         params = {
             'limit': limit,
             'offset': offset,
+            **extra_params
         }
         return self.request_get('transactions/unconfirmed', params)
 

--- a/client/api/wallets.py
+++ b/client/api/wallets.py
@@ -20,10 +20,12 @@ class Wallets(Resource):
     def get(self, wallet_id):
         return self.request_get('wallets/{}'.format(wallet_id))
 
-    def transactions(self, wallet_id, page=None, limit=100):
+    def transactions(self, wallet_id, page=None, limit=100, **kwargs):
+        extra_params = {name: kwargs[name] for name in kwargs if kwargs[name] is not None}
         params = {
             'page': page,
             'limit': limit,
+            **extra_params
         }
         return self.request_get('wallets/{}/transactions'.format(wallet_id), params)
 

--- a/tests/api/test_blocks.py
+++ b/tests/api/test_blocks.py
@@ -35,6 +35,24 @@ def test_all_calls_correct_url_with_passed_in_params():
     assert 'limit=69' in responses.calls[0].request.url
 
 
+def test_all_calls_correct_url_with_additional_params():
+    responses.add(
+      responses.GET,
+      'http://127.0.0.1:4002/blocks',
+      json={'success': True},
+      status=200
+    )
+
+    client = ArkClient('http://127.0.0.1:4002')
+    client.blocks.all(page=5, limit=69, orderBy="timestamp.epoch", height=6838329)
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url.startswith('http://127.0.0.1:4002/blocks?')
+    assert 'page=5' in responses.calls[0].request.url
+    assert 'limit=69' in responses.calls[0].request.url
+    assert 'orderBy=timestamp.epoch' in responses.calls[0].request.url
+    assert 'height=6838329' in responses.calls[0].request.url
+
+
 def test_get_calls_correct_url():
     block_id = '12345'
     responses.add(

--- a/tests/api/test_delegates.py
+++ b/tests/api/test_delegates.py
@@ -35,6 +35,23 @@ def test_all_calls_correct_url_with_passed_in_params():
     assert 'limit=69' in responses.calls[0].request.url
 
 
+def test_all_calls_correct_url_with_additional_params():
+    responses.add(
+      responses.GET,
+      'http://127.0.0.1:4002/delegates',
+      json={'success': True},
+      status=200
+    )
+
+    client = ArkClient('http://127.0.0.1:4002')
+    client.delegates.all(page=5, limit=69, orderBy="username")
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url.startswith('http://127.0.0.1:4002/delegates?')
+    assert 'page=5' in responses.calls[0].request.url
+    assert 'limit=69' in responses.calls[0].request.url
+    assert 'orderBy=username' in responses.calls[0].request.url
+
+
 def test_get_calls_correct_url():
     delegate_id = '12345'
     responses.add(

--- a/tests/api/test_transactions.py
+++ b/tests/api/test_transactions.py
@@ -35,6 +35,23 @@ def test_all_calls_correct_url_with_passed_in_params():
     assert 'limit=69' in responses.calls[0].request.url
 
 
+def test_all_calls_correct_url_with_additional_params():
+    responses.add(
+      responses.GET,
+      'http://127.0.0.1:4002/transactions',
+      json={'success': True},
+      status=200
+    )
+
+    client = ArkClient('http://127.0.0.1:4002')
+    client.transactions.all(page=5, limit=69, orderBy="timestamp.epoch")
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url.startswith('http://127.0.0.1:4002/transactions?')
+    assert 'page=5' in responses.calls[0].request.url
+    assert 'limit=69' in responses.calls[0].request.url
+    assert 'orderBy=timestamp.epoch' in responses.calls[0].request.url
+
+
 def test_create_calls_correct_url_with_data():
     responses.add(
         responses.POST,
@@ -100,6 +117,23 @@ def test_all_unconfirmed_calls_correct_url_with_passed_in_params():
     )
     assert 'offset=5' in responses.calls[0].request.url
     assert 'limit=69' in responses.calls[0].request.url
+
+
+def test_all_unconfirmed_calls_correct_url_with_additional_params():
+    responses.add(
+      responses.GET,
+      'http://127.0.0.1:4002/transactions/unconfirmed',
+      json={'success': True},
+      status=200
+    )
+
+    client = ArkClient('http://127.0.0.1:4002')
+    client.transactions.all_unconfirmed(page=5, limit=69, orderBy="timestamp.epoch")
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url.startswith('http://127.0.0.1:4002/transactions/unconfirmed?')
+    assert 'page=5' in responses.calls[0].request.url
+    assert 'limit=69' in responses.calls[0].request.url
+    assert 'orderBy=timestamp.epoch' in responses.calls[0].request.url
 
 
 def test_search_calls_correct_url_with_default_params():

--- a/tests/api/test_wallets.py
+++ b/tests/api/test_wallets.py
@@ -98,6 +98,24 @@ def test_transactions_calls_correct_url_with_default_params():
     )
 
 
+def test_transactions_calls_correct_url_with_additional_params():
+    wallet_id = '12345'
+    responses.add(
+      responses.GET,
+      'http://127.0.0.1:4002/wallets/{}/transactions'.format(wallet_id),
+      json={'success': True},
+      status=200
+    )
+
+    client = ArkClient('http://127.0.0.1:4002')
+    client.wallets.transactions(wallet_id=wallet_id, page=5, limit=69, orderBy="timestamp.epoch")
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url.startswith('http://127.0.0.1:4002/wallets/12345/transactions?')
+    assert 'page=5' in responses.calls[0].request.url
+    assert 'limit=69' in responses.calls[0].request.url
+    assert 'orderBy=timestamp.epoch' in responses.calls[0].request.url
+
+
 def test_transactions_calls_correct_url_with_passed_in_params():
     wallet_id = '12345'
     responses.add(


### PR DESCRIPTION
## Proposed changes

This change allow the use of every parameters usable when directly querying the API, like using `orderBy` to order the blocks and many more.

Redoing the pr I previously did [here](https://github.com/ArkEcosystem/python-client/pull/56). This change can be done in two different ways ; with **kwargs like I did in this PR, or by using default arguments like it's done [here](https://github.com/ArkEcosystem/python-client/blob/master/client/api/peers.py) in the Peers class.

If the **kwargs are prefered, it might be good to document the possible arguments directly in the code or in the official documentation of the python client.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)