### PR TITLE
Add Webhooks support to Python-Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 1.1.0 - 2019-01-01
+
+### Added
+- Webhooks Support
+
 ## 1.0.0 - 2018-12-24
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-## 1.1.0 - 2019-01-01
+## 1.1.0 - 2018-12-29
 
 ### Added
 - Webhooks Support

--- a/client/api/webhooks.py
+++ b/client/api/webhooks.py
@@ -2,7 +2,7 @@ from client.resource import Resource
 
 
 class Webhooks(Resource):
-        
+
     def get(self, page=None, limit=100):
         params = {
             'page': page,
@@ -13,7 +13,7 @@ class Webhooks(Resource):
     def retrieve(self, webhook_id):
         return self.request_get('webhooks/{}'.format(webhook_id))
 
-    def create(self, event, target, conditions, enabled="true"):
+    def create(self, event, target, conditions, enabled='true'):
         return self.request_post('webhooks', data={'event': event,
                                                    'target': target,
                                                    'conditions': conditions,

--- a/client/api/webhooks.py
+++ b/client/api/webhooks.py
@@ -14,7 +14,6 @@ class Webhooks(Resource):
         return self.request_get('webhooks/{}'.format(webhook_id))
 
     def create(self, event, target, conditions, enabled=None):
-        self.swap_ports()
         return self.request_post('webhooks', data={'event': event,
                                                    'target': target,
                                                    'conditions': conditions,

--- a/client/api/webhooks.py
+++ b/client/api/webhooks.py
@@ -27,4 +27,4 @@ class Webhooks(Resource):
                                       'enabled': enabled})
 
     def delete(self, webhook_id):
-        return self.request_delete('webhooks/{}'.format(webhook_id))
+        self.request_delete('webhooks/{}'.format(webhook_id))

--- a/client/api/webhooks.py
+++ b/client/api/webhooks.py
@@ -22,6 +22,6 @@ class Webhooks(Resource):
     def update(self, webhook_id, **kwargs):
         extra_params = {name: kwargs[name] for name in kwargs if kwargs[name] is not None}
         return self.request_put('webhooks/{}'.format(webhook_id), data={**extra_params})
-       
+
     def delete(self, webhook_id):
         return self.request_delete('webhooks/{}'.format(webhook_id))

--- a/client/api/webhooks.py
+++ b/client/api/webhooks.py
@@ -27,4 +27,4 @@ class Webhooks(Resource):
                                       'enabled': enabled})
 
     def delete(self, webhook_id):
-        self.request_delete('webhooks/{}'.format(webhook_id))
+        return self.request_delete('webhooks/{}'.format(webhook_id))

--- a/client/api/webhooks.py
+++ b/client/api/webhooks.py
@@ -19,12 +19,9 @@ class Webhooks(Resource):
                                                    'conditions': conditions,
                                                    'enabled': enabled})
 
-    def update(self, webhook_id, event=None, target=None, conditions=None, enabled=None):
-        return self.request_put('webhooks/{}'.format(webhook_id),
-                                data={'event': event,
-                                      'target': target,
-                                      'conditions': conditions,
-                                      'enabled': enabled})
-
+    def update(self, webhook_id, **kwargs):
+        extra_params = {name: kwargs[name] for name in kwargs if kwargs[name] is not None}
+        return self.request_put('webhooks/{}'.format(webhook_id), data={**extra params)
+       
     def delete(self, webhook_id):
         return self.request_delete('webhooks/{}'.format(webhook_id))

--- a/client/api/webhooks.py
+++ b/client/api/webhooks.py
@@ -21,7 +21,7 @@ class Webhooks(Resource):
 
     def update(self, webhook_id, **kwargs):
         extra_params = {name: kwargs[name] for name in kwargs if kwargs[name] is not None}
-        return self.request_put('webhooks/{}'.format(webhook_id), data={**extra params)
+        return self.request_put('webhooks/{}'.format(webhook_id), data={**extra_params)
        
     def delete(self, webhook_id):
         return self.request_delete('webhooks/{}'.format(webhook_id))

--- a/client/api/webhooks.py
+++ b/client/api/webhooks.py
@@ -21,7 +21,7 @@ class Webhooks(Resource):
 
     def update(self, webhook_id, **kwargs):
         extra_params = {name: kwargs[name] for name in kwargs if kwargs[name] is not None}
-        return self.request_put('webhooks/{}'.format(webhook_id), data={**extra_params)
+        return self.request_put('webhooks/{}'.format(webhook_id), data={**extra_params})
        
     def delete(self, webhook_id):
         return self.request_delete('webhooks/{}'.format(webhook_id))

--- a/client/api/webhooks.py
+++ b/client/api/webhooks.py
@@ -13,7 +13,7 @@ class Webhooks(Resource):
     def retrieve(self, webhook_id):
         return self.request_get('webhooks/{}'.format(webhook_id))
 
-    def create(self, event, target, conditions, enabled=None):
+    def create(self, event, target, conditions, enabled="true"):
         return self.request_post('webhooks', data={'event': event,
                                                    'target': target,
                                                    'conditions': conditions,

--- a/client/client.py
+++ b/client/client.py
@@ -5,11 +5,11 @@ import pkgutil
 from importlib import import_module
 from pathlib import Path
 
+from dotenv import load_dotenv
+
 from client.connection import Connection
 from client.exceptions import ArkParameterException
 from client.resource import Resource
-
-from dotenv import load_dotenv
 
 
 class ArkClient(object):

--- a/client/client.py
+++ b/client/client.py
@@ -41,7 +41,7 @@ class ArkClient(object):
                         setattr(self, name, attribute(self._swap_port()))  
                     else:
                         setattr(self, name, attribute(self.connection))
-     
+
     def _swap_port(self):
         """
         Dynamically swaps Webhooks port during module import
@@ -49,7 +49,7 @@ class ArkClient(object):
         env = str(Path.home()) + '/.ark/.env'
         if os.path.exists(env) is True:
             load_dotenv(env)
-            api = os.getenv('ARK_API_PORT') 
+            api = os.getenv('ARK_API_PORT')
             webhook = os.getenv('ARK_WEBHOOKS_PORT')
         else:
             api = '4003'

--- a/client/client.py
+++ b/client/client.py
@@ -40,9 +40,9 @@ class ArkClient(object):
                     if name == "webhooks":
                         print("True")
                         new_connection = self._swap_port()
+                        print(new_connection.hostname)
                         setattr(self, name, attribute(new_connection))  
                     else:
-                        print("False")
                         setattr(self, name, attribute(self.connection))
                         print(name, self.connection.hostname)
                         

--- a/client/client.py
+++ b/client/client.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from client.connection import Connection
 from client.exceptions import ArkParameterException
 from client.resource import Resource
+
 from dotenv import load_dotenv
 
 

--- a/client/client.py
+++ b/client/client.py
@@ -49,7 +49,7 @@ class ArkClient(object):
      
     def _swap_port(self):
         """
-        Dynamically swaps Webhooks port
+        Dynamically swaps Webhooks port during module import
         """
         env = str(Path.home()) + '/.ark/.env'
         if os.path.exists(env) is True:
@@ -61,6 +61,3 @@ class ArkClient(object):
             webhook = "4004"
 
         return Connection(self.connection.hostname.replace(api,webhook))
-        #newhost = self.connection.hostname.replace(api,webhook)
-
-        #Connection(self.connection.hostname.replace(api,webhook))

--- a/client/client.py
+++ b/client/client.py
@@ -27,7 +27,6 @@ class ArkClient(object):
         for _, name, _ in modules:
             module = import_module('client.api.{}'.format(name))
             for attr in dir(module):
-                print(attr)
                 # If attr name is `Resource`, skip it as it's a class and also has a
                 # subclass of Resource
                 if attr == 'Resource':
@@ -36,5 +35,5 @@ class ArkClient(object):
                 attribute = getattr(module, attr)
                 if inspect.isclass(attribute) and issubclass(attribute, Resource):
                     # Set module class as a property on the client
-                    setattr(self, name, attribute(self.connection.hostname))
-                    print(name, self.connection)
+                    setattr(self, name, attribute(self.connection))
+                    print(name, self.connection.hostname)

--- a/client/client.py
+++ b/client/client.py
@@ -37,3 +37,4 @@ class ArkClient(object):
                 if inspect.isclass(attribute) and issubclass(attribute, Resource):
                     # Set module class as a property on the client
                     setattr(self, name, attribute(self.connection))
+                    print(name, self.connection)

--- a/client/client.py
+++ b/client/client.py
@@ -9,6 +9,7 @@ from client.connection import Connection
 from client.exceptions import ArkParameterException
 from client.resource import Resource
 
+
 class ArkClient(object):
 
     def __init__(self, hostname):
@@ -25,7 +26,6 @@ class ArkClient(object):
         Dynamically imports API endpoints.
         """
         modules = pkgutil.iter_modules([str(Path(__file__).parent / 'api')])
-        print(modules)
         for _, name, _ in modules:
             module = import_module('client.api.{}'.format(name))
             for attr in dir(module):
@@ -37,8 +37,7 @@ class ArkClient(object):
                 attribute = getattr(module, attr)
                 if inspect.isclass(attribute) and issubclass(attribute, Resource):
                     # Set module class as a property on the client
-                    if name == "webhooks":
-                        #new_connection = self._swap_port()
+                    if name == 'webhooks':
                         setattr(self, name, attribute(self._swap_port()))  
                     else:
                         setattr(self, name, attribute(self.connection))

--- a/client/client.py
+++ b/client/client.py
@@ -1,13 +1,14 @@
-from dotenv import load_dotenv
+
 import inspect
+import os
 import pkgutil
 from importlib import import_module
-import os
 from pathlib import Path
 
 from client.connection import Connection
 from client.exceptions import ArkParameterException
 from client.resource import Resource
+from dotenv import load_dotenv
 
 
 class ArkClient(object):

--- a/client/client.py
+++ b/client/client.py
@@ -27,6 +27,7 @@ class ArkClient(object):
         for _, name, _ in modules:
             module = import_module('client.api.{}'.format(name))
             for attr in dir(module):
+                print(attr)
                 # If attr name is `Resource`, skip it as it's a class and also has a
                 # subclass of Resource
                 if attr == 'Resource':

--- a/client/client.py
+++ b/client/client.py
@@ -36,5 +36,5 @@ class ArkClient(object):
                 attribute = getattr(module, attr)
                 if inspect.isclass(attribute) and issubclass(attribute, Resource):
                     # Set module class as a property on the client
-                    setattr(self, name, attribute(self.connection))
+                    setattr(self, name, attribute(self.connection.hostmane))
                     print(name, self.connection)

--- a/client/client.py
+++ b/client/client.py
@@ -1,6 +1,8 @@
+from dotenv import load_dotenv
 import inspect
 import pkgutil
 from importlib import import_module
+import os
 from pathlib import Path
 
 from client.connection import Connection
@@ -35,8 +37,27 @@ class ArkClient(object):
                 attribute = getattr(module, attr)
                 if inspect.isclass(attribute) and issubclass(attribute, Resource):
                     # Set module class as a property on the client
-                    setattr(self, name, attribute(self.connection))
-                    print(name, self.connection.hostname)
+                    if name is "webhooks":
+                        new_connection = _swap_port()
+                        setattr(self, name, attribute(new_connection))  
+                    else:
+                        setattr(self, name, attribute(self.connection))
+                        print(name, self.connection.hostname)
      
     def _swap_port(self):
-      
+        """
+        Dynamically swaps Webhooks port
+        """
+        env = str(Path.home()) + '/.ark/.env'
+        if os.path.exists(env) is True:
+            load_dotenv(env)
+            api = os.getenv("ARK_API_PORT") 
+            webhook = os.getenv("ARK_WEBHOOKS_PORT")
+        else:
+            api = "4003"
+            webhook = "4004"
+
+        newhost = self.connection.hostname.replace(api,webhook)
+        print(newhost)
+        quit()
+        Connection(self.connection.hostname.replace(api,webhook))

--- a/client/client.py
+++ b/client/client.py
@@ -60,7 +60,7 @@ class ArkClient(object):
             api = "4003"
             webhook = "4004"
 
-        newhost = self.connection.hostname.replace(api,webhook)
-        print(newhost)
-        quit()
-        Connection(self.connection.hostname.replace(api,webhook))
+        return Connection(self.connection.hostname.replace(api,webhook))
+        #newhost = self.connection.hostname.replace(api,webhook)
+
+        #Connection(self.connection.hostname.replace(api,webhook))

--- a/client/client.py
+++ b/client/client.py
@@ -23,6 +23,7 @@ class ArkClient(object):
         Dynamically imports API endpoints.
         """
         modules = pkgutil.iter_modules([str(Path(__file__).parent / 'api')])
+        print(modules)
         for _, name, _ in modules:
             module = import_module('client.api.{}'.format(name))
             for attr in dir(module):

--- a/client/client.py
+++ b/client/client.py
@@ -37,3 +37,6 @@ class ArkClient(object):
                     # Set module class as a property on the client
                     setattr(self, name, attribute(self.connection))
                     print(name, self.connection.hostname)
+     
+    def _swap_port(self):
+      

--- a/client/client.py
+++ b/client/client.py
@@ -38,11 +38,14 @@ class ArkClient(object):
                 if inspect.isclass(attribute) and issubclass(attribute, Resource):
                     # Set module class as a property on the client
                     if name is "webhooks":
+                        print("True")
                         new_connection = _swap_port()
                         setattr(self, name, attribute(new_connection))  
                     else:
+                        print("False")
                         setattr(self, name, attribute(self.connection))
                         print(name, self.connection.hostname)
+                        
      
     def _swap_port(self):
         """

--- a/client/client.py
+++ b/client/client.py
@@ -13,7 +13,7 @@ class ArkClient(object):
 
     def __init__(self, hostname):
         """
-        :param string hostname: Node hostname. Examples: `http://127.0.0.1:4002` or
+        :param string hostname: Node hostname. Examples: `http://127.0.0.1:4003` or
             `http://my.domain.io/api/`. This is to allow people to server the api
             on whatever url they want.
         """
@@ -50,10 +50,10 @@ class ArkClient(object):
         env = str(Path.home()) + '/.ark/.env'
         if os.path.exists(env) is True:
             load_dotenv(env)
-            api = os.getenv("ARK_API_PORT") 
-            webhook = os.getenv("ARK_WEBHOOKS_PORT")
+            api = os.getenv('ARK_API_PORT) 
+            webhook = os.getenv('ARK_WEBHOOKS_PORT')
         else:
-            api = "4003"
-            webhook = "4004"
+            api = '4003'
+            webhook = '4004'
 
         return Connection(self.connection.hostname.replace(api,webhook))

--- a/client/client.py
+++ b/client/client.py
@@ -39,7 +39,7 @@ class ArkClient(object):
                     # Set module class as a property on the client
                     if name == "webhooks":
                         print("True")
-                        new_connection = _swap_port()
+                        new_connection = self._swap_port()
                         setattr(self, name, attribute(new_connection))  
                     else:
                         print("False")

--- a/client/client.py
+++ b/client/client.py
@@ -50,10 +50,10 @@ class ArkClient(object):
         env = str(Path.home()) + '/.ark/.env'
         if os.path.exists(env) is True:
             load_dotenv(env)
-            api = os.getenv('ARK_API_PORT) 
+            api = os.getenv('ARK_API_PORT') 
             webhook = os.getenv('ARK_WEBHOOKS_PORT')
         else:
             api = '4003'
             webhook = '4004'
 
-        return Connection(self.connection.hostname.replace(api,webhook))
+        return Connection(self.connection.hostname.replace(api, webhook))

--- a/client/client.py
+++ b/client/client.py
@@ -38,7 +38,7 @@ class ArkClient(object):
                 if inspect.isclass(attribute) and issubclass(attribute, Resource):
                     # Set module class as a property on the client
                     if name == 'webhooks':
-                        setattr(self, name, attribute(self._swap_port()))  
+                        setattr(self, name, attribute(self._swap_port()))
                     else:
                         setattr(self, name, attribute(self.connection))
 

--- a/client/client.py
+++ b/client/client.py
@@ -36,5 +36,5 @@ class ArkClient(object):
                 attribute = getattr(module, attr)
                 if inspect.isclass(attribute) and issubclass(attribute, Resource):
                     # Set module class as a property on the client
-                    setattr(self, name, attribute(self.connection.hostmane))
+                    setattr(self, name, attribute(self.connection.hostname))
                     print(name, self.connection)

--- a/client/client.py
+++ b/client/client.py
@@ -38,14 +38,10 @@ class ArkClient(object):
                 if inspect.isclass(attribute) and issubclass(attribute, Resource):
                     # Set module class as a property on the client
                     if name == "webhooks":
-                        print("True")
-                        new_connection = self._swap_port()
-                        print(new_connection.hostname)
-                        setattr(self, name, attribute(new_connection))  
+                        #new_connection = self._swap_port()
+                        setattr(self, name, attribute(self._swap_port()))  
                     else:
                         setattr(self, name, attribute(self.connection))
-                        print(name, self.connection.hostname)
-                        
      
     def _swap_port(self):
         """

--- a/client/client.py
+++ b/client/client.py
@@ -37,7 +37,7 @@ class ArkClient(object):
                 attribute = getattr(module, attr)
                 if inspect.isclass(attribute) and issubclass(attribute, Resource):
                     # Set module class as a property on the client
-                    if name is "webhooks":
+                    if name == "webhooks":
                         print("True")
                         new_connection = _swap_port()
                         setattr(self, name, attribute(new_connection))  

--- a/client/connection.py
+++ b/client/connection.py
@@ -49,7 +49,7 @@ class Connection(object):
 
     def _handle_response(self, response):
         if not response.content:
-            print("response.content")
+            print(response.content)
             raise ArkHTTPException('No content in response', response=response)
 
         body = response.json()

--- a/client/connection.py
+++ b/client/connection.py
@@ -49,6 +49,7 @@ class Connection(object):
 
     def _handle_response(self, response):
         if not response.content:
+            print("response.content")
             raise ArkHTTPException('No content in response', response=response)
 
         body = response.json()

--- a/client/connection.py
+++ b/client/connection.py
@@ -49,7 +49,7 @@ class Connection(object):
 
     def _handle_response(self, response):
         if not response.content:
-            print(response.content)
+            print(response)
             raise ArkHTTPException('No content in response', response=response)
 
         body = response.json()

--- a/client/connection.py
+++ b/client/connection.py
@@ -49,7 +49,6 @@ class Connection(object):
 
     def _handle_response(self, response):
         if not response.content:
-            print(response.status_code)
             raise ArkHTTPException('No content in response', response=response)
 
         body = response.json()

--- a/client/connection.py
+++ b/client/connection.py
@@ -49,7 +49,7 @@ class Connection(object):
 
     def _handle_response(self, response):
         if not response.content:
-            print(response)
+            print(response.status_code)
             raise ArkHTTPException('No content in response', response=response)
 
         body = response.json()

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ import setuptools
 requires = [
     'requests>=2.19.1',
     'backoff>=1.6.0',
+    'python-dotenv>=0.10.1',
 ]
 
 tests_require = [

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup_requires = ['pytest-runner'] if {'pytest', 'test', 'ptr'}.intersection(sys
 setuptools.setup(
     name='arkecosystem-client',
     description='A simple Python API client for the ARK Blockchain.',
-    version='1.0.0',
+    version='1.1.0',
     author='Ark Ecosystem',
     author_email='info@client.io',
     url='https://github.com/ArkEcosystem/python-client',

--- a/tests/api/test_transactions.py
+++ b/tests/api/test_transactions.py
@@ -8,15 +8,15 @@ from client import ArkClient
 def test_all_calls_correct_url_with_default_params():
     responses.add(
         responses.GET,
-        'http://127.0.0.1:4002/transactions',
+        'http://127.0.0.1:4003/transactions',
         json={'success': True},
         status=200
     )
 
-    client = ArkClient('http://127.0.0.1:4002')
+    client = ArkClient('http://127.0.0.1:4003')
     client.transactions.all()
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/transactions?limit=100'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4003/transactions?limit=100'
 
 
 def test_all_calls_correct_url_with_passed_in_params():

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -78,10 +78,12 @@ def test_update_calls_correct_url_with_data():
     )
 
     client = ArkClient('http://127.0.0.1:4004')
-    client.webhooks.update(webhook_id, {'random':'data'})
+    client.webhooks.update(webhook_id = webhook_id, enabled = 'false')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == 'http://127.0.0.1:4004/webhooks/1'
-    assert json.loads(responses.calls[0].request.body.decode()) == {'random':'data'}
+    assert 'enabled=false' in response.calls[0].request.url
+    assert json.loads(responses.calls[0].request.body.decode()) == {'event' : 'block.forged',
+        'target' : '127.0.0.1:5000', 'conditions' : [{'random' : 'data'}], 'enabled' : 'false'}
 
 
 def test_delete_calls_correct_url():

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -66,48 +66,30 @@ def test_create_calls_correct_url_with_passed_in_params():
     assert responses.calls[0].request.url.startswith('http://127.0.0.1:4004/api/webhooks?')
     assert json.loads(responses.calls[0].request.body.decode()) == {
         'event' : 'block.forged', 'target : '127.0.0.1:5000', 
-        'conditions' : [{'random':'data'}], 'enabled':'true'
-
-
-##### UPDATE PUT REQUESTS
-def test_update_calls_correct_url_with_default_params():
-    delegate_id = '12345'
-    responses.add(
-        responses.GET,
-        'http://127.0.0.1:4002/delegates/{}/blocks'.format(delegate_id),
-        json={'success': True},
-        status=200
-    )
-
-    client = ArkClient('http://127.0.0.1:4002')
-    client.delegates.blocks(delegate_id)
-    assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == (
-        'http://127.0.0.1:4002/delegates/12345/blocks?limit=100'
-    )
+        'conditions' : [{'random':'data'}], 'enabled':'true'}
 
 
 def test_update_calls_correct_url_with_passed_in_params():
-    delegate_id = '12345'
+    webhook_id = 1
     responses.add(
-        responses.GET,
-        'http://127.0.0.1:4002/delegates/{}/blocks'.format(delegate_id),
+        responses.PUT,
+        'http://127.0.0.1:4004/webhooks/{}'.format(webhook_id),
         json={'success': True},
         status=200
     )
 
-    client = ArkClient('http://127.0.0.1:4002')
-    client.delegates.blocks(delegate_id, page=5, limit=69)
+    client = ArkClient('http://127.0.0.1:4004')
+    client.webhooks.update(event='block.forged', target='127.0.0.1:5000', 
+                           conditions=[{'random':'data'}], enabled='false')
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url.startswith(
-        'http://127.0.0.1:4002/delegates/12345/blocks?'
-    )
-    assert 'page=5' in responses.calls[0].request.url
-    assert 'limit=69' in responses.calls[0].request.url
+    assert responses.calls[0].request.url.startswith('http://127.0.0.1:4004/api/webhooks/1?')
+    assert json.loads(responses.calls[0].request.body.decode()) == {
+        'event' : 'block.forged', 'target : '127.0.0.1:5000', 
+        'conditions' : [{'random':'data'}], 'enabled':'false'}
 
 
 def test_delete_calls_correct_url():
-    webhook_id = '1'
+    webhook_id = 1
     responses.add(
         responses.GET,
         'http://127.0.0.1:4004/webhooks/{}'.format(webhook_id),

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -1,0 +1,170 @@
+import json
+
+import responses
+
+from client import ArkClient
+
+
+def test_all_calls_correct_url_with_default_params():
+    responses.add(
+        responses.GET,
+        'http://127.0.0.1:4002/delegates',
+        json={'success': True},
+        status=200
+    )
+
+    client = ArkClient('http://127.0.0.1:4002')
+    client.delegates.all()
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/delegates?limit=100'
+
+
+def test_all_calls_correct_url_with_passed_in_params():
+    responses.add(
+        responses.GET,
+        'http://127.0.0.1:4002/delegates',
+        json={'success': True},
+        status=200
+    )
+
+    client = ArkClient('http://127.0.0.1:4002')
+    client.delegates.all(page=5, limit=69)
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url.startswith('http://127.0.0.1:4002/delegates?')
+    assert 'page=5' in responses.calls[0].request.url
+    assert 'limit=69' in responses.calls[0].request.url
+
+
+def test_get_calls_correct_url():
+    delegate_id = '12345'
+    responses.add(
+        responses.GET,
+        'http://127.0.0.1:4002/delegates/{}'.format(delegate_id),
+        json={'success': True},
+        status=200
+    )
+
+    client = ArkClient('http://127.0.0.1:4002')
+    client.delegates.get(delegate_id)
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/delegates/12345'
+
+
+def test_search_calls_correct_url_with_default_params():
+    responses.add(
+        responses.POST,
+        'http://127.0.0.1:4002/delegates/search',
+        json={'success': True},
+        status=200
+    )
+
+    client = ArkClient('http://127.0.0.1:4002')
+    client.delegates.search('deadlock')
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/delegates/search?limit=100'
+    assert json.loads(responses.calls[0].request.body.decode()) == {'username': 'deadlock'}
+
+
+def test_search_calls_correct_url_with_passed_in_params():
+    responses.add(
+        responses.POST,
+        'http://127.0.0.1:4002/delegates/search',
+        json={'success': True},
+        status=200
+    )
+
+    client = ArkClient('http://127.0.0.1:4002')
+    client.delegates.search('deadlock', page=5, limit=69)
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url.startswith('http://127.0.0.1:4002/delegates/search?')
+    assert 'page=5' in responses.calls[0].request.url
+    assert 'limit=69' in responses.calls[0].request.url
+    assert json.loads(responses.calls[0].request.body.decode()) == {'username': 'deadlock'}
+
+
+def test_blocks_calls_correct_url_with_default_params():
+    delegate_id = '12345'
+    responses.add(
+        responses.GET,
+        'http://127.0.0.1:4002/delegates/{}/blocks'.format(delegate_id),
+        json={'success': True},
+        status=200
+    )
+
+    client = ArkClient('http://127.0.0.1:4002')
+    client.delegates.blocks(delegate_id)
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == (
+        'http://127.0.0.1:4002/delegates/12345/blocks?limit=100'
+    )
+
+
+def test_blocks_calls_correct_url_with_passed_in_params():
+    delegate_id = '12345'
+    responses.add(
+        responses.GET,
+        'http://127.0.0.1:4002/delegates/{}/blocks'.format(delegate_id),
+        json={'success': True},
+        status=200
+    )
+
+    client = ArkClient('http://127.0.0.1:4002')
+    client.delegates.blocks(delegate_id, page=5, limit=69)
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url.startswith(
+        'http://127.0.0.1:4002/delegates/12345/blocks?'
+    )
+    assert 'page=5' in responses.calls[0].request.url
+    assert 'limit=69' in responses.calls[0].request.url
+
+
+def test_voters_calls_correct_url_with_default_params():
+    delegate_id = '12345'
+    responses.add(
+        responses.GET,
+        'http://127.0.0.1:4002/delegates/{}/voters'.format(delegate_id),
+        json={'success': True},
+        status=200
+    )
+
+    client = ArkClient('http://127.0.0.1:4002')
+    client.delegates.voters(delegate_id)
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == (
+        'http://127.0.0.1:4002/delegates/12345/voters?limit=100'
+    )
+
+
+def test_bvoters_calls_correct_url_with_passed_in_params():
+    delegate_id = '12345'
+    responses.add(
+        responses.GET,
+        'http://127.0.0.1:4002/delegates/{}/voters'.format(delegate_id),
+        json={'success': True},
+        status=200
+    )
+
+    client = ArkClient('http://127.0.0.1:4002')
+    client.delegates.voters(delegate_id, page=5, limit=69)
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url.startswith(
+        'http://127.0.0.1:4002/delegates/12345/voters?'
+    )
+    assert 'page=5' in responses.calls[0].request.url
+    assert 'limit=69' in responses.calls[0].request.url
+
+
+def test_voter_balances_calls_correct_url_with_default_params():
+    delegate_id = '12345'
+    responses.add(
+        responses.GET,
+        'http://127.0.0.1:4002/delegates/{}/voters/balances'.format(delegate_id),
+        json={'success': True},
+        status=200
+    )
+
+    client = ArkClient('http://127.0.0.1:4002')
+    client.delegates.voter_balances(delegate_id)
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/delegates/12345/voters/balances'

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -62,7 +62,7 @@ def test_create_calls_correct_url_with_passed_in_params():
     client = ArkClient('http://127.0.0.1:4004')
     client.webhooks.create('block.forged', '127.0.0.1:5000', [{'random':'data'}], 'true')
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url.startswith('http://127.0.0.1:4004/api/webhooks?')
+    assert responses.calls[0].request.url.startswith('http://127.0.0.1:4004/api/webhooks')
     assert json.loads(responses.calls[0].request.body.decode()) == {
         'event' : 'block.forged', 'target' : '127.0.0.1:5000', 
         'conditions' : [{'random':'data'}], 'enabled':'true'}
@@ -80,7 +80,7 @@ def test_update_calls_correct_url_with_passed_in_params():
     client = ArkClient('http://127.0.0.1:4004')
     client.webhooks.update(webhook_id, 'block.forged', '127.0.0.1:5000', [{'random':'data'}], 'false')
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url.startswith('http://127.0.0.1:4004/api/webhooks/1?')
+    assert responses.calls[0].request.url.startswith('http://127.0.0.1:4004/api/webhooks/1')
     assert json.loads(responses.calls[0].request.body.decode()) == {
         'event' : 'block.forged', 'target' : '127.0.0.1:5000', 
         'conditions' : [{'random':'data'}], 'enabled':'false'}

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -54,7 +54,7 @@ def test_retrieve_calls_correct_url():
 def test_create_calls_correct_url_with_passed_in_params():
     responses.add(
         responses.POST,
-        'http://127.0.0.1:4004/webhooks/',
+        'http://127.0.0.1:4004/webhooks',
         json={'success': True},
         status=200
     )

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -68,7 +68,7 @@ def test_create_calls_correct_url_with_data():
         'conditions' : [{'random':'data'}], 'enabled':'true'}
 
 
-def test_update_calls_correct_url_with_passed_in_params():
+def test_update_calls_correct_url_with_data():
     webhook_id = 1
     responses.add(
         responses.PUT,
@@ -78,12 +78,10 @@ def test_update_calls_correct_url_with_passed_in_params():
     )
 
     client = ArkClient('http://127.0.0.1:4004')
-    client.webhooks.update(webhook_id, 'block.forged', '127.0.0.1:5000', [{'random':'data'}], 'false')
+    client.webhooks.update(webhook_id, {'random':'data'})
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == 'http://127.0.0.1:4004/webhooks/1'
-    assert json.loads(responses.calls[0].request.body.decode()) == {
-        'event' : 'block.forged', 'target' : '127.0.0.1:5000', 
-        'conditions' : [{'random':'data'}], 'enabled':'false'}
+    assert json.loads(responses.calls[0].request.body.decode()) == {'random':'data'}
 
 
 def test_delete_calls_correct_url():

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -87,7 +87,7 @@ def test_update_calls_correct_url_with_data():
 def test_delete_calls_correct_url():
     webhook_id = 1
     responses.add(
-        responses.GET,
+        responses.DELETE,
         'http://127.0.0.1:4004/webhooks/{}'.format(webhook_id),
         json={'success': True},
         status=200

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -62,7 +62,7 @@ def test_create_calls_correct_url_with_data():
     client = ArkClient('http://127.0.0.1:4004')
     client.webhooks.create('block.forged', '127.0.0.1:5000', [{'random':'data'}], 'true')
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url.startswith('http://127.0.0.1:4004/api/webhooks')
+    assert responses.calls[0].request.url('http://127.0.0.1:4004/api/webhooks')
     assert json.loads(responses.calls[0].request.body.decode()) == {
         'event' : 'block.forged', 'target' : '127.0.0.1:5000', 
         'conditions' : [{'random':'data'}], 'enabled':'true'}

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -8,50 +8,50 @@ from client import ArkClient
 def test_get_calls_correct_url_with_default_params():
     responses.add(
         responses.GET,
-        'http://127.0.0.1:4002/delegates',
+        'http://127.0.0.1:4004/webhooks',
         json={'success': True},
         status=200
     )
 
-    client = ArkClient('http://127.0.0.1:4002')
-    client.delegates.all()
+    client = ArkClient('http://127.0.0.1:4004')
+    client.webhooks.get()
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/delegates?limit=100'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4004/webhooks?limit=100'
 
 
 def test_get_calls_correct_url_with_passed_in_params():
     responses.add(
         responses.GET,
-        'http://127.0.0.1:4002/delegates',
+        'http://127.0.0.1:4004/webhooks',
         json={'success': True},
         status=200
     )
 
-    client = ArkClient('http://127.0.0.1:4002')
-    client.delegates.all(page=5, limit=69)
+    client = ArkClient('http://127.0.0.1:4004')
+    client.webhooks.get(page=5, limit=69)
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url.startswith('http://127.0.0.1:4002/delegates?')
+    assert responses.calls[0].request.url.startswith('http://127.0.0.1:4004/webhooks?')
     assert 'page=5' in responses.calls[0].request.url
     assert 'limit=69' in responses.calls[0].request.url
 
 
 def test_retrieve_calls_correct_url():
-    delegate_id = '12345'
+    webhook_id = 1
     responses.add(
         responses.GET,
-        'http://127.0.0.1:4002/delegates/{}'.format(delegate_id),
+        'http://127.0.0.1:4004/webhooks/{}'.format(webhook_id),
         json={'success': True},
         status=200
     )
 
-    client = ArkClient('http://127.0.0.1:4002')
-    client.delegates.get(delegate_id)
+    client = ArkClient('http://127.0.0.1:4004')
+    client.webhook.retrieve(webhook_id)
 
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/delegates/12345'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4004/webhooks/1'
 
 ##### ADD CREATE TESTS
-    
+##### UPDATE PUT REQUESTS
 def test_update_calls_correct_url_with_default_params():
     delegate_id = '12345'
     responses.add(
@@ -89,16 +89,16 @@ def test_update_calls_correct_url_with_passed_in_params():
 
 
 def test_delete_calls_correct_url():
-    delegate_id = '12345'
+    webhook_id = '1'
     responses.add(
         responses.GET,
-        'http://127.0.0.1:4002/delegates/{}'.format(delegate_id),
+        'http://127.0.0.1:4004/webhooks/{}'.format(webhook_id),
         json={'success': True},
         status=200
     )
 
-    client = ArkClient('http://127.0.0.1:4002')
-    client.delegates.get(delegate_id)
+    client = ArkClient('http://127.0.0.1:4004')
+    client.webhooks.delete(webhook_id)
 
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/delegates/12345'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4004/webhooks/1'

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -45,7 +45,7 @@ def test_retrieve_calls_correct_url():
     )
 
     client = ArkClient('http://127.0.0.1:4004')
-    client.webhook.retrieve(webhook_id)
+    client.webhooks.retrieve(webhook_id)
 
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == 'http://127.0.0.1:4004/webhooks/1'

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -65,7 +65,7 @@ def test_create_calls_correct_url_with_passed_in_params():
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith('http://127.0.0.1:4004/api/webhooks?')
     assert json.loads(responses.calls[0].request.body.decode()) == {
-        'event' : 'block.forged', 'target : '127.0.0.1:5000', 
+        'event' : 'block.forged', 'target' : '127.0.0.1:5000', 
         'conditions' : [{'random':'data'}], 'enabled':'true'}
 
 
@@ -84,7 +84,7 @@ def test_update_calls_correct_url_with_passed_in_params():
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith('http://127.0.0.1:4004/api/webhooks/1?')
     assert json.loads(responses.calls[0].request.body.decode()) == {
-        'event' : 'block.forged', 'target : '127.0.0.1:5000', 
+        'event' : 'block.forged', 'target' : '127.0.0.1:5000', 
         'conditions' : [{'random':'data'}], 'enabled':'false'}
 
 

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -62,7 +62,7 @@ def test_create_calls_correct_url_with_data():
     client = ArkClient('http://127.0.0.1:4004')
     client.webhooks.create('block.forged', '127.0.0.1:5000', [{'random':'data'}], 'true')
     assert len(responses.calls) == 1
-    assert responses.calls[0].request == 'http://127.0.0.1:4004/api/webhooks'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4004/api/webhooks'
     assert json.loads(responses.calls[0].request.body.decode()) == {
         'event' : 'block.forged', 'target' : '127.0.0.1:5000', 
         'conditions' : [{'random':'data'}], 'enabled':'true'}

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -60,8 +60,8 @@ def test_create_calls_correct_url_with_passed_in_params():
     )
 
     client = ArkClient('http://127.0.0.1:4004')
-    client.webhooks.create(event='block.forged', target='127.0.0.1:5000', 
-                           conditions=[{'random':'data'}], enabled='true')
+    client.webhooks.create(event = 'block.forged', target = '127.0.0.1:5000', 
+                           conditions = [{'random':'data'}], enabled = 'true')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith('http://127.0.0.1:4004/api/webhooks?')
     assert json.loads(responses.calls[0].request.body.decode()) == {
@@ -79,8 +79,8 @@ def test_update_calls_correct_url_with_passed_in_params():
     )
 
     client = ArkClient('http://127.0.0.1:4004')
-    client.webhooks.update(event='block.forged', target='127.0.0.1:5000', 
-                           conditions=[{'random':'data'}], enabled='false')
+    client.webhooks.update(event = 'block.forged', target = '127.0.0.1:5000', 
+                           conditions = [{'random':'data'}], enabled = 'false')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith('http://127.0.0.1:4004/api/webhooks/1?')
     assert json.loads(responses.calls[0].request.body.decode()) == {

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -81,7 +81,6 @@ def test_update_calls_correct_url_with_data():
     client.webhooks.update(webhook_id = webhook_id, enabled = 'false')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == 'http://127.0.0.1:4004/webhooks/1'
-    assert 'enabled=false' in responses.calls[0].request.url
     assert json.loads(responses.calls[0].request.body.decode()) == {'event' : 'block.forged',
         'target' : '127.0.0.1:5000', 'conditions' : [{'random' : 'data'}], 'enabled' : 'false'}
 

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -81,7 +81,7 @@ def test_update_calls_correct_url_with_data():
     client.webhooks.update(webhook_id = webhook_id, enabled = 'false')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == 'http://127.0.0.1:4004/webhooks/1'
-    assert 'enabled=false' in response.calls[0].request.url
+    assert 'enabled=false' in responses.calls[0].request.url
     assert json.loads(responses.calls[0].request.body.decode()) == {'event' : 'block.forged',
         'target' : '127.0.0.1:5000', 'conditions' : [{'random' : 'data'}], 'enabled' : 'false'}
 

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -51,7 +51,7 @@ def test_retrieve_calls_correct_url():
     assert responses.calls[0].request.url == 'http://127.0.0.1:4004/webhooks/1'
 
     
-def test_create_calls_correct_url_with_passed_in_params():
+def test_create_calls_correct_url_with_data():
     responses.add(
         responses.POST,
         'http://127.0.0.1:4004/webhooks',

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -50,7 +50,25 @@ def test_retrieve_calls_correct_url():
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == 'http://127.0.0.1:4004/webhooks/1'
 
-##### ADD CREATE TESTS
+    
+def test_create_calls_correct_url_with_passed_in_params():
+    responses.add(
+        responses.POST,
+        'http://127.0.0.1:4004/webhooks/',
+        json={'success': True},
+        status=200
+    )
+
+    client = ArkClient('http://127.0.0.1:4004')
+    client.webhooks.create(event='block.forged', target='127.0.0.1:5000/post', 
+                           conditions=[{'random':'data'}], enabled='true')
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url.startswith('http://127.0.0.1:4004/api/webhooks?')
+    assert json.loads(responses.calls[0].request.body.decode()) == {
+        'event' : 'block.forged', 'target : '127.0.0.1:5000/post', 
+        'conditions' : [{'random':'data'}], 'enabled':'true'
+
+
 ##### UPDATE PUT REQUESTS
 def test_update_calls_correct_url_with_default_params():
     delegate_id = '12345'

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -62,7 +62,7 @@ def test_create_calls_correct_url_with_data():
     client = ArkClient('http://127.0.0.1:4004')
     client.webhooks.create('block.forged', '127.0.0.1:5000', [{'random':'data'}], 'true')
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url('http://127.0.0.1:4004/api/webhooks')
+    assert responses.calls[0].request == 'http://127.0.0.1:4004/api/webhooks'
     assert json.loads(responses.calls[0].request.body.decode()) == {
         'event' : 'block.forged', 'target' : '127.0.0.1:5000', 
         'conditions' : [{'random':'data'}], 'enabled':'true'}

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -60,12 +60,12 @@ def test_create_calls_correct_url_with_passed_in_params():
     )
 
     client = ArkClient('http://127.0.0.1:4004')
-    client.webhooks.create(event='block.forged', target='127.0.0.1:5000/post', 
+    client.webhooks.create(event='block.forged', target='127.0.0.1:5000', 
                            conditions=[{'random':'data'}], enabled='true')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith('http://127.0.0.1:4004/api/webhooks?')
     assert json.loads(responses.calls[0].request.body.decode()) == {
-        'event' : 'block.forged', 'target : '127.0.0.1:5000/post', 
+        'event' : 'block.forged', 'target : '127.0.0.1:5000', 
         'conditions' : [{'random':'data'}], 'enabled':'true'
 
 

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -5,7 +5,7 @@ import responses
 from client import ArkClient
 
 
-def test_all_calls_correct_url_with_default_params():
+def test_get_calls_correct_url_with_default_params():
     responses.add(
         responses.GET,
         'http://127.0.0.1:4002/delegates',
@@ -19,7 +19,7 @@ def test_all_calls_correct_url_with_default_params():
     assert responses.calls[0].request.url == 'http://127.0.0.1:4002/delegates?limit=100'
 
 
-def test_all_calls_correct_url_with_passed_in_params():
+def test_get_calls_correct_url_with_passed_in_params():
     responses.add(
         responses.GET,
         'http://127.0.0.1:4002/delegates',
@@ -35,7 +35,7 @@ def test_all_calls_correct_url_with_passed_in_params():
     assert 'limit=69' in responses.calls[0].request.url
 
 
-def test_get_calls_correct_url():
+def test_retrieve_calls_correct_url():
     delegate_id = '12345'
     responses.add(
         responses.GET,
@@ -50,40 +50,9 @@ def test_get_calls_correct_url():
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == 'http://127.0.0.1:4002/delegates/12345'
 
-
-def test_search_calls_correct_url_with_default_params():
-    responses.add(
-        responses.POST,
-        'http://127.0.0.1:4002/delegates/search',
-        json={'success': True},
-        status=200
-    )
-
-    client = ArkClient('http://127.0.0.1:4002')
-    client.delegates.search('deadlock')
-    assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/delegates/search?limit=100'
-    assert json.loads(responses.calls[0].request.body.decode()) == {'username': 'deadlock'}
-
-
-def test_search_calls_correct_url_with_passed_in_params():
-    responses.add(
-        responses.POST,
-        'http://127.0.0.1:4002/delegates/search',
-        json={'success': True},
-        status=200
-    )
-
-    client = ArkClient('http://127.0.0.1:4002')
-    client.delegates.search('deadlock', page=5, limit=69)
-    assert len(responses.calls) == 1
-    assert responses.calls[0].request.url.startswith('http://127.0.0.1:4002/delegates/search?')
-    assert 'page=5' in responses.calls[0].request.url
-    assert 'limit=69' in responses.calls[0].request.url
-    assert json.loads(responses.calls[0].request.body.decode()) == {'username': 'deadlock'}
-
-
-def test_blocks_calls_correct_url_with_default_params():
+##### ADD CREATE TESTS
+    
+def test_update_calls_correct_url_with_default_params():
     delegate_id = '12345'
     responses.add(
         responses.GET,
@@ -100,7 +69,7 @@ def test_blocks_calls_correct_url_with_default_params():
     )
 
 
-def test_blocks_calls_correct_url_with_passed_in_params():
+def test_update_calls_correct_url_with_passed_in_params():
     delegate_id = '12345'
     responses.add(
         responses.GET,
@@ -119,52 +88,17 @@ def test_blocks_calls_correct_url_with_passed_in_params():
     assert 'limit=69' in responses.calls[0].request.url
 
 
-def test_voters_calls_correct_url_with_default_params():
+def test_delete_calls_correct_url():
     delegate_id = '12345'
     responses.add(
         responses.GET,
-        'http://127.0.0.1:4002/delegates/{}/voters'.format(delegate_id),
+        'http://127.0.0.1:4002/delegates/{}'.format(delegate_id),
         json={'success': True},
         status=200
     )
 
     client = ArkClient('http://127.0.0.1:4002')
-    client.delegates.voters(delegate_id)
+    client.delegates.get(delegate_id)
+
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == (
-        'http://127.0.0.1:4002/delegates/12345/voters?limit=100'
-    )
-
-
-def test_bvoters_calls_correct_url_with_passed_in_params():
-    delegate_id = '12345'
-    responses.add(
-        responses.GET,
-        'http://127.0.0.1:4002/delegates/{}/voters'.format(delegate_id),
-        json={'success': True},
-        status=200
-    )
-
-    client = ArkClient('http://127.0.0.1:4002')
-    client.delegates.voters(delegate_id, page=5, limit=69)
-    assert len(responses.calls) == 1
-    assert responses.calls[0].request.url.startswith(
-        'http://127.0.0.1:4002/delegates/12345/voters?'
-    )
-    assert 'page=5' in responses.calls[0].request.url
-    assert 'limit=69' in responses.calls[0].request.url
-
-
-def test_voter_balances_calls_correct_url_with_default_params():
-    delegate_id = '12345'
-    responses.add(
-        responses.GET,
-        'http://127.0.0.1:4002/delegates/{}/voters/balances'.format(delegate_id),
-        json={'success': True},
-        status=200
-    )
-
-    client = ArkClient('http://127.0.0.1:4002')
-    client.delegates.voter_balances(delegate_id)
-    assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/delegates/12345/voters/balances'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/delegates/12345'

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -62,7 +62,7 @@ def test_create_calls_correct_url_with_data():
     client = ArkClient('http://127.0.0.1:4004')
     client.webhooks.create('block.forged', '127.0.0.1:5000', [{'random':'data'}], 'true')
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4004/api/webhooks'
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4004/webhooks'
     assert json.loads(responses.calls[0].request.body.decode()) == {
         'event' : 'block.forged', 'target' : '127.0.0.1:5000', 
         'conditions' : [{'random':'data'}], 'enabled':'true'}
@@ -80,7 +80,7 @@ def test_update_calls_correct_url_with_passed_in_params():
     client = ArkClient('http://127.0.0.1:4004')
     client.webhooks.update(webhook_id, 'block.forged', '127.0.0.1:5000', [{'random':'data'}], 'false')
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url.startswith('http://127.0.0.1:4004/api/webhooks/1')
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4004/webhooks/1'
     assert json.loads(responses.calls[0].request.body.decode()) == {
         'event' : 'block.forged', 'target' : '127.0.0.1:5000', 
         'conditions' : [{'random':'data'}], 'enabled':'false'}

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -81,8 +81,7 @@ def test_update_calls_correct_url_with_data():
     client.webhooks.update(webhook_id = webhook_id, enabled = 'false')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == 'http://127.0.0.1:4004/webhooks/1'
-    assert json.loads(responses.calls[0].request.body.decode()) == {'event' : 'block.forged',
-        'target' : '127.0.0.1:5000', 'conditions' : [{'random' : 'data'}], 'enabled' : 'false'}
+    assert json.loads(responses.calls[0].request.body.decode()) == {'enabled' : 'false'}
 
 
 def test_delete_calls_correct_url():

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -60,8 +60,7 @@ def test_create_calls_correct_url_with_passed_in_params():
     )
 
     client = ArkClient('http://127.0.0.1:4004')
-    client.webhooks.create(event = 'block.forged', target = '127.0.0.1:5000', 
-                           conditions = [{'random':'data'}], enabled = 'true')
+    client.webhooks.create('block.forged', '127.0.0.1:5000', [{'random':'data'}], 'true')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith('http://127.0.0.1:4004/api/webhooks?')
     assert json.loads(responses.calls[0].request.body.decode()) == {
@@ -79,8 +78,7 @@ def test_update_calls_correct_url_with_passed_in_params():
     )
 
     client = ArkClient('http://127.0.0.1:4004')
-    client.webhooks.update(event = 'block.forged', target = '127.0.0.1:5000', 
-                           conditions = [{'random':'data'}], enabled = 'false')
+    client.webhooks.update(webhook_id, 'block.forged', '127.0.0.1:5000', [{'random':'data'}], 'false')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith('http://127.0.0.1:4004/api/webhooks/1?')
     assert json.loads(responses.calls[0].request.body.decode()) == {


### PR DESCRIPTION
## Proposed changes
<!--
Added webhooks support to the python-client to allow it to interact with them as well as the standard API requests. Also added a dynamic port switch so that the client can be used with a single ArkClient('http://127.0.0.1:4003') object for both API's (Port 4003) and Webhooks (4004). 
-->

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [X] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

## Further comments
<!--
The webhooks update and delete functions both work properly but currently return an ARKHTTP error because of the no content responses. I have added an issue to the core github for that to be addressed. Once fixed in the core, will work properly without the ARKHTTP error in the python-client.
-->
