### PR TITLE
refactor: remove deprecated voter balances endpoint from client

### DIFF
--- a/client/api/delegates.py
+++ b/client/api/delegates.py
@@ -35,6 +35,3 @@ class Delegates(Resource):
             'limit': limit,
         }
         return self.request_get('delegates/{}/voters'.format(delegate_id), params)
-
-    def voter_balances(self, delegate_id):
-        return self.request_get('delegates/{}/voters/balances'.format(delegate_id))

--- a/tests/api/test_delegates.py
+++ b/tests/api/test_delegates.py
@@ -153,7 +153,7 @@ def test_voters_calls_correct_url_with_default_params():
     )
 
 
-def test_bvoters_calls_correct_url_with_passed_in_params():
+def test_voters_calls_correct_url_with_passed_in_params():
     delegate_id = '12345'
     responses.add(
         responses.GET,
@@ -170,18 +170,3 @@ def test_bvoters_calls_correct_url_with_passed_in_params():
     )
     assert 'page=5' in responses.calls[0].request.url
     assert 'limit=69' in responses.calls[0].request.url
-
-
-def test_voter_balances_calls_correct_url_with_default_params():
-    delegate_id = '12345'
-    responses.add(
-        responses.GET,
-        'http://127.0.0.1:4002/delegates/{}/voters/balances'.format(delegate_id),
-        json={'success': True},
-        status=200
-    )
-
-    client = ArkClient('http://127.0.0.1:4002')
-    client.delegates.voter_balances(delegate_id)
-    assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/delegates/12345/voters/balances'


### PR DESCRIPTION
## Proposed changes
<!--
Removed the recently deprecated voter balances endpoint from the python client
-->

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [X] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
