### PR TITLE
refactor: remove version argument remains

### DIFF
--- a/client/connection.py
+++ b/client/connection.py
@@ -44,7 +44,6 @@ class Connection(object):
 
         self.session.headers.update({
             'Content-Type': 'application/json',
-            'API-Version': '2'
         })
 
     def _handle_response(self, response):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -13,7 +13,6 @@ def test_connection_creation_sets_default_session_headers_and_variables():
     assert connection.hostname == 'http://127.0.0.1:4003'
     assert isinstance(connection.session, requests.Session)
     assert connection.session.headers['Content-Type'] == 'application/json'
-    assert connection.session.headers['API-Version'] == '2'
 
 def test_connection_request_retry_successful():
     responses.add(


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Remove all code that related to setting an API-Version as Core 2.5 will only serve the v2 API.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
