### PR TITLE
ci: stop testing against python 3.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.5, 3.6, 3.7]
+        python-version: [3.6, 3.7]
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Python 3.5 has reached end-of-life. Python 3.5.10 is the final release of 3.5.