### PR TITLE
feat: evm api endpoint

### DIFF
--- a/client/api/blocks.py
+++ b/client/api/blocks.py
@@ -10,7 +10,7 @@ class Blocks(Resource):
             'limit': limit,
             **extra_params
         }
-        return self.request_get('blocks', params)
+        return self.with_endpoint('api').request_get('blocks', params)
 
     def get(self, block_id):
         return self.with_endpoint('api').request_get(f'blocks/{block_id}')

--- a/client/api/evm.py
+++ b/client/api/evm.py
@@ -1,0 +1,12 @@
+from typing import Any
+from client.resource import Resource
+
+
+class EVM(Resource):
+    def eth_call(self, params: list[dict[str, Any]]):
+        return self.with_endpoint('evm').request_post('', {
+            'jsonrpc': "2.0",
+            'method': "eth_call",
+            'params': [params, "latest"],
+            'id': None,
+        })

--- a/client/api/votes.py
+++ b/client/api/votes.py
@@ -8,7 +8,7 @@ class Votes(Resource):
             'page': page,
             'limit': limit,
         }
-        return self.request_get('votes', params)
+        return self.with_endpoint('api').request_get('votes', params)
 
     def get(self, vote_id):
         return self.with_endpoint('api').request_get(f'votes/{vote_id}')

--- a/client/client.py
+++ b/client/client.py
@@ -1,4 +1,5 @@
 from typing import Union
+from client.api.evm import EVM
 from client.connection import ClientHosts, Connection
 from client.api.api_nodes import ApiNodes
 from client.api.blockchain import Blockchain
@@ -59,6 +60,14 @@ class ArkClient(object):
         :rtype: client.api.delegates.Delegates
         """
         return Delegates(self.connection)
+
+    @property
+    def evm(self):
+        """
+        :return: EVM API
+        :rtype: client.api.evm.EVM
+        """
+        return EVM(self.connection)
 
     @property
     def node(self):

--- a/tests/api/test_evm.py
+++ b/tests/api/test_evm.py
@@ -1,0 +1,24 @@
+import json
+import responses
+
+from client import ArkClient
+
+
+def test_eth_call_methods_correct_url():
+    responses.add(
+        responses.POST,
+        'http://127.0.0.1:4002/evm/api/',
+        json={'success': True},
+        status=200
+    )
+
+    client = ArkClient('http://127.0.0.1:4002/evm/api')
+    client.evm.eth_call([{ 'random': 'data' }])
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == 'http://127.0.0.1:4002/evm/api/'
+    assert json.loads(responses.calls[0].request.body.decode()) == {
+        'jsonrpc': '2.0',
+        'method': 'eth_call',
+        'params': [[{ 'random': 'data' }], 'latest'],
+        'id': None,
+    }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,6 +12,7 @@ def test_client():
     assert hasattr(client, 'blocks') == True
     assert hasattr(client, 'commits') == True
     assert hasattr(client, 'delegates') == True
+    assert hasattr(client, 'evm') == True
     assert hasattr(client, 'node') == True
     assert hasattr(client, 'peers') == True
     assert hasattr(client, 'rounds') == True


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dwavj81

Also adds some missing `with_endpoint('api')` references for a couple of endpoints. It could have caused a scenario where doing an EVM or create transaction call, then doing a `Blocks.all()` or `Votes.all()` call would result in the latter being performed on the wrong API

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
